### PR TITLE
fix: removed ibc dependency on x/rollapp/types

### DIFF
--- a/x/rollapp/keeper/msg_server_create_rollapp.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp.go
@@ -29,7 +29,9 @@ func (k msgServer) CreateRollapp(goCtx context.Context, msg *types.MsgCreateRoll
 		}
 		if !bInWhitelist {
 			return nil, types.ErrUnauthorizedRollappCreator
-		} else if item.MaxRollapps > 0 {
+		}
+
+		if item.MaxRollapps > 0 {
 			// if MaxRollapps, it means there is a limit for this creator
 			// count how many rollapps he created
 			rollappsNumOfCreator := uint64(0)

--- a/x/rollapp/types/message_create_rollapp.go
+++ b/x/rollapp/types/message_create_rollapp.go
@@ -3,8 +3,6 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
-	ibcclienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	"github.com/dymensionxyz/dymension/shared/types"
 )
 
@@ -46,15 +44,6 @@ func (msg *MsgCreateRollapp) GetSignBytes() []byte {
 }
 
 func (msg *MsgCreateRollapp) ValidateBasic() error {
-	// rollappId is the chainID of the rollapp
-	// in order to prevent confusion with ibc revision formats
-	// we prevent to create a rollapps with a name compiling to revision format
-	if ibcclienttypes.IsRevisionFormat(msg.RollappId) {
-		return sdkerrors.Wrapf(
-			ErrInvalidRollappID, "RollappID can not be in revision format: %s", msg.RollappId,
-		)
-	}
-
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)

--- a/x/rollapp/types/message_create_rollapp_test.go
+++ b/x/rollapp/types/message_create_rollapp_test.go
@@ -17,15 +17,6 @@ func TestMsgCreateRollapp_ValidateBasic(t *testing.T) {
 		err  error
 	}{
 		{
-			name: "invalid rollappId",
-			msg: MsgCreateRollapp{
-				Creator:              sample.AccAddress(),
-				MaxSequencers:        1,
-				MaxWithholdingBlocks: 1,
-				RollappId:            "ivalid-3",
-			},
-			err: ErrInvalidRollappID,
-		}, {
 			name: "invalid address",
 			msg: MsgCreateRollapp{
 				Creator:              "invalid_address",
@@ -88,7 +79,7 @@ func TestMsgCreateRollapp_ValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.err != nil {
-				require.ErrorIs(t, err, tt.err)
+				require.ErrorIs(t, err, tt.err, "test %s failed", tt.name)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
This PR removes the additional check that rollapp-id shouldn't have revision format.

For now, there is no justification for this check.
It conflicts with standard chain-id naming, and introduces IBC dependency to whoever uses the `rollapp` module (e.g dymint)



# PR Standards

## Opening a pull request should be able to meet the following requirements:

---

For Author:

- [ ]  Targeted PR against correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to Github issue with discussion and accepted design
- [ ]  Targets only one github issue
- [ ]  Wrote unit and integration tests
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

--- 

After reviewer approval:

- [ ]  In case targets main branch, PR should be squashed and merged.
- [ ]  In case PR targets a release branch, PR should be rebased.
