### PR TITLE
refactor: Remove ValidateBasic in cli

### DIFF
--- a/x/rollapp/client/cli/tx_create_rollapp.go
+++ b/x/rollapp/client/cli/tx_create_rollapp.go
@@ -62,9 +62,6 @@ func CmdCreateRollapp() *cobra.Command {
 				metadatas,
 			)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/rollapp/client/cli/tx_update_state.go
+++ b/x/rollapp/client/cli/tx_update_state.go
@@ -55,9 +55,7 @@ func CmdUpdateState() *cobra.Command {
 				argVersion,
 				argBDs,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
+
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/sequencer/client/cli/tx_create_sequencer.go
+++ b/x/sequencer/client/cli/tx_create_sequencer.go
@@ -50,9 +50,6 @@ func CmdCreateSequencer() *cobra.Command {
 				return err
 			}
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/streamer/client/cli/tx_create_stream.go
+++ b/x/streamer/client/cli/tx_create_stream.go
@@ -74,10 +74,6 @@ func NewCmdSubmitCreateStreamProposal() *cobra.Command {
 				return err
 			}
 
-			if err = msg.ValidateBasic(); err != nil {
-				return err
-			}
-
 			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
 			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},

--- a/x/streamer/client/cli/tx_replace_distribution.go
+++ b/x/streamer/client/cli/tx_replace_distribution.go
@@ -45,10 +45,6 @@ func NewCmdSubmitReplaceStreamDistributionProposal() *cobra.Command {
 				return err
 			}
 
-			if err = msg.ValidateBasic(); err != nil {
-				return err
-			}
-
 			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
 			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},

--- a/x/streamer/client/cli/tx_terminate_stream.go
+++ b/x/streamer/client/cli/tx_terminate_stream.go
@@ -41,10 +41,6 @@ func NewCmdSubmitTerminateStreamProposal() *cobra.Command {
 				return err
 			}
 
-			if err = msg.ValidateBasic(); err != nil {
-				return err
-			}
-
 			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
 			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},

--- a/x/streamer/client/cli/tx_update_distribution.go
+++ b/x/streamer/client/cli/tx_update_distribution.go
@@ -45,10 +45,6 @@ func NewCmdSubmitUpdateStreamDistributionProposal() *cobra.Command {
 				return err
 			}
 
-			if err = msg.ValidateBasic(); err != nil {
-				return err
-			}
-
 			txf := tx.NewFactoryCLI(clientCtx, cmd.Flags()).WithTxConfig(clientCtx.TxConfig).WithAccountRetriever(clientCtx.AccountRetriever)
 			return tx.GenerateOrBroadcastTxWithFactory(clientCtx, txf, msg)
 		},


### PR DESCRIPTION
# PR Standards

## Description

The `ValidateBasic` function has been called in the `GenerateOrBroadcastTxWithFactory` function, so we no longer need to add the `ValidateBasic` function when writing Cli. Related PRs can be viewed at: https://github.com/cosmos/cosmos-sdk/pull/9236#discussion_r623803504

## Opening a pull request should be able to meet the following requirements:

---

For Author:

- [ ]  Targeted PR against the correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)

---

For Reviewer:

- [ ]  confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  confirmed all author checklist items have been addressed

---;

After reviewer approval:

- [ ]  In case it targets the main branch, PR should be squashed and merged.
- [ ]  In case the PR targets a release branch, PR should be rebased.
