### PR TITLE
feat(evm): integrate virtual frontier bank contract

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	evmclient "github.com/evmos/ethermint/x/evm/client"
 	"io"
 	"net/http"
 	"os"
@@ -143,10 +142,11 @@ import (
 
 	"github.com/evmos/ethermint/ethereum/eip712"
 
-	extended_evm_keeper "github.com/dymensionxyz/dymension/v3/x/evm/keeper"
+	extendedevmkeeper "github.com/dymensionxyz/dymension/v3/x/evm/keeper"
 	"github.com/evmos/ethermint/server/flags"
 	ethermint "github.com/evmos/ethermint/types"
 	"github.com/evmos/ethermint/x/evm"
+	evmclient "github.com/evmos/ethermint/x/evm/client"
 	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/evmos/ethermint/x/evm/vm/geth"
@@ -647,7 +647,7 @@ func New(
 			app.StreamerKeeper.Hooks(),
 			app.TxFeesKeeper.Hooks(),
 			app.DelayedAckKeeper.GetEpochHooks(),
-			extended_evm_keeper.NewEvmEpochHooks(*app.EvmKeeper, app.BankKeeper),
+			extendedevmkeeper.NewEvmEpochHooks(*app.EvmKeeper, app.BankKeeper),
 		),
 	)
 

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 )
@@ -17,5 +18,15 @@ type GenesisState map[string]json.RawMessage
 
 // NewDefaultGenesisState generates the default state for the application.
 func NewDefaultGenesisState(cdc codec.JSONCodec) GenesisState {
-	return ModuleBasics.DefaultGenesis(cdc)
+	defaultGenesisState := ModuleBasics.DefaultGenesis(cdc)
+
+	if evmGenesisStateJson, found := defaultGenesisState[evmtypes.ModuleName]; found {
+		// force disable Enable Create of x/evm
+		var evmGenesisState evmtypes.GenesisState
+		cdc.MustUnmarshalJSON(evmGenesisStateJson, &evmGenesisState)
+		evmGenesisState.Params.EnableCreate = false
+		defaultGenesisState[evmtypes.ModuleName] = cdc.MustMarshalJSON(&evmGenesisState)
+	}
+
+	return defaultGenesisState
 }

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -20,6 +20,7 @@ GENESIS_FILE="$CONFIG_DIRECTORY/genesis.json"
 CHAIN_ID=${CHAIN_ID:-"dymension_100-1"}
 MONIKER_NAME=${MONIKER_NAME:-"local"}
 KEY_NAME=${KEY_NAME:-"local-user"}
+MNEMONIC="curtain hat remain song receive tower stereo hope frog cheap brown plate raccoon post reflect wool sail salmon game salon group glimpse adult shift"
 
 # Setting non-default ports to avoid port conflicts when running local rollapp
 SETTLEMENT_ADDR=${SETTLEMENT_ADDR:-"0.0.0.0:36657"}
@@ -105,7 +106,7 @@ if [ ! "$answer" != "${answer#[Nn]}" ] ;then
   dymd add-genesis-account $(dymd keys show user --keyring-backend test -a) 1000000000000000000000adym,10000000000uatom
 fi
 
-dymd keys add "$KEY_NAME" --keyring-backend test
+echo "$MNEMONIC" | dymd keys add "$KEY_NAME" --recover --keyring-backend test
 dymd add-genesis-account "$(dymd keys show "$KEY_NAME" -a --keyring-backend test)" "$TOKEN_AMOUNT"
 
 dymd gentx "$KEY_NAME" "$STAKING_AMOUNT" --chain-id "$CHAIN_ID" --keyring-backend test

--- a/x/evm/keeper/epoch_hooks.go
+++ b/x/evm/keeper/epoch_hooks.go
@@ -1,0 +1,109 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	ethermintutils "github.com/evmos/ethermint/utils"
+	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
+	epochstypes "github.com/osmosis-labs/osmosis/v15/x/epochs/types"
+	"strings"
+)
+
+// EvmEpochHooks is the wrapper struct for the epoch-hook evm keeper.
+type EvmEpochHooks struct {
+	ek evmkeeper.Keeper
+	bk bankkeeper.Keeper
+}
+
+var _ epochstypes.EpochHooks = EvmEpochHooks{}
+
+// NewEvmEpochHooks returns the epoch-hook wrapper struct.
+func NewEvmEpochHooks(ek evmkeeper.Keeper, bk bankkeeper.Keeper) EvmEpochHooks {
+	return EvmEpochHooks{ek, bk}
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                 epoch hooks                                */
+/* -------------------------------------------------------------------------- */
+
+const triggerVirtualFrontierBankContractRegistrationAtEpochIdentifier = "day"
+
+// BeforeEpochStart is the epoch start hook.
+func (h EvmEpochHooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	if err := h.deployAVirtualFrontierBankSmartContractOnLocalNet(ctx); err != nil {
+		return err
+	}
+
+	if epochIdentifier == triggerVirtualFrontierBankContractRegistrationAtEpochIdentifier {
+		return h.ek.DeployVirtualFrontierBankContractForAllBankDenomMetadataRecords(ctx, nil)
+	}
+
+	return nil
+}
+
+// AfterEpochEnd is the epoch end hook.
+func (h EvmEpochHooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber int64) error {
+	return nil
+}
+
+func (h EvmEpochHooks) deployAVirtualFrontierBankSmartContractOnLocalNet(ctx sdk.Context) error {
+	if ctx.BlockHeight() != 1 {
+		return nil
+	}
+
+	isLocalNet := ctx.ChainID() == "dymension_100-1" || !ethermintutils.IsOneOfDymensionChains(ctx)
+	if !isLocalNet {
+		return nil
+	}
+
+	base := h.ek.GetParams(ctx).EvmDenom
+	_, foundMetadata := h.bk.GetDenomMetaData(ctx, base)
+	if !foundMetadata {
+		display := strings.ToUpper(base[1:])
+		metadata := banktypes.Metadata{
+			Description: display,
+			DenomUnits: []*banktypes.DenomUnit{
+				{
+					Denom:    base,
+					Exponent: 0,
+				},
+				{
+					Denom:    display,
+					Exponent: 18,
+				},
+			},
+			Base:    base,
+			Display: display,
+			Name:    display,
+			Symbol:  display,
+		}
+
+		h.bk.SetDenomMetaData(ctx, metadata)
+	}
+
+	_, foundContract := h.ek.GetVirtualFrontierBankContractAddressByDenom(ctx, base)
+	if foundContract {
+		return nil
+	}
+
+	// 0xbd8eff67ca469df5cd89f7a9b2890f043188d695 is the contract address of the first virtual frontier bank contract
+	err := h.ek.DeployVirtualFrontierBankContractForAllBankDenomMetadataRecords(ctx, func(banktypes.Metadata) bool {
+		// deploy all
+		return true
+	})
+	if err != nil {
+		return err
+	}
+
+	// the contract for native denom is disabled by default so we need to enable it
+	contractAddress, _ := h.ek.GetVirtualFrontierBankContractAddressByDenom(ctx, base)
+	vfContract := h.ek.GetVirtualFrontierContract(ctx, contractAddress)
+	vfContract.Active = true
+	err = h.ek.SetVirtualFrontierContract(ctx, contractAddress, vfContract)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/evm/keeper/epoch_hooks.go
+++ b/x/evm/keeper/epoch_hooks.go
@@ -39,8 +39,9 @@ func (h EvmEpochHooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string,
 	}
 
 	if epochIdentifier == triggerVirtualFrontierBankContractRegistrationAtEpochIdentifier {
-		// deploy virtual frontier bank contracts for all IBC denom (default)
-		err = h.ek.DeployVirtualFrontierBankContractForAllBankDenomMetadataRecords(ctx, nil)
+		err = h.ek.DeployVirtualFrontierBankContractForAllBankDenomMetadataRecords(ctx, func(metadata banktypes.Metadata) bool {
+			return strings.HasPrefix(metadata.Base, "ibc/") // only deploy for IBC denoms
+		})
 		if err != nil {
 			return err
 		}

--- a/x/evm/keeper/epoch_hooks_test.go
+++ b/x/evm/keeper/epoch_hooks_test.go
@@ -1,0 +1,214 @@
+package keeper_test
+
+import (
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	extended_evm_keeper "github.com/dymensionxyz/dymension/v3/x/evm/keeper"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/suite"
+)
+
+var _ = suite.TestingSuite(nil)
+
+func (suite *KeeperTestSuite) TestHookOperation_BeforeEpochStart() {
+	suite.SetupTest()
+
+	denomAdym := createDenomMetadata("adym", "DYM", 18)
+	suite.Require().Nil(denomAdym.Validate(), "bad setup")
+	suite.App.BankKeeper.SetDenomMetaData(suite.Ctx, denomAdym)
+
+	denomAphoton := createDenomMetadata("aphoton", "PHOTON", 18)
+	suite.Require().Nil(denomAphoton.Validate(), "bad setup")
+	suite.App.BankKeeper.SetDenomMetaData(suite.Ctx, denomAphoton)
+
+	denomIbcAtom := createDenomMetadata("ibc/uatom", "ATOM", 6)
+	suite.Require().Nil(denomIbcAtom.Validate(), "bad setup")
+	suite.App.BankKeeper.SetDenomMetaData(suite.Ctx, denomIbcAtom)
+
+	denomIbcOsmo := createDenomMetadata("ibc/uosmo", "OSMO", 6)
+	suite.Require().Nil(denomIbcOsmo.Validate(), "bad setup")
+	suite.App.BankKeeper.SetDenomMetaData(suite.Ctx, denomIbcOsmo)
+
+	const epochIdentifier = "day"
+
+	hooks := extended_evm_keeper.NewEvmEpochHooks(*suite.App.EvmKeeper, suite.App.BankKeeper)
+
+	suite.Ctx = suite.Ctx.WithBlockHeight(0) // ignore invoking x/evm exec for contract deployment
+
+	/* ------------------------- call in-correct epoch hook ------------------------- */
+	err := hooks.BeforeEpochStart(suite.Ctx, "month", 0)
+	suite.Require().NoError(err)
+
+	_, foundAdym := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAdym.Base)
+	suite.Require().False(foundAdym)
+	_, foundAphoton := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAphoton.Base)
+	suite.Require().False(foundAphoton)
+	_, foundIbcAtom := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcAtom.Base)
+	suite.Require().False(foundIbcAtom)
+	_, foundIbcOsmo := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcOsmo.Base)
+	suite.Require().False(foundIbcOsmo)
+
+	/* ------------------------- call corresponding epoch hook ------------------------- */
+	err = hooks.BeforeEpochStart(suite.Ctx, epochIdentifier, 0)
+	suite.Require().NoError(err)
+
+	_, found := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAdym.Base)
+	suite.Require().False(found, "only deploy VFBC for IBC denom")
+
+	_, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAphoton.Base)
+	suite.Require().False(found, "only deploy VFBC for IBC denom")
+
+	originalVfbcIbcAtomAddr, found := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcAtom.Base)
+	suite.Require().True(found)
+	suite.Require().NotEqual(common.Address{}, originalVfbcIbcAtomAddr)
+
+	originalVfbcIbcOsmoAddr, found := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcOsmo.Base)
+	suite.Require().True(found)
+	suite.Require().NotEqual(common.Address{}, originalVfbcIbcOsmoAddr)
+
+	originalVfbcIbcAtom := suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcAtomAddr)
+	suite.Require().NotNil(originalVfbcIbcAtom)
+
+	originalVfbcIbcOsmo := suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcOsmoAddr)
+	suite.Require().NotNil(originalVfbcIbcOsmo)
+
+	suite.Require().NotEqual(originalVfbcIbcAtomAddr, originalVfbcIbcOsmoAddr, "contract addresses must be different")
+
+	/* ------------------------- call epoch hook again ------------------------- */
+
+	err = hooks.BeforeEpochStart(suite.Ctx, epochIdentifier, 0)
+	suite.Require().NoError(err)
+
+	_, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAdym.Base)
+	suite.Require().False(found, "only deploy VFBC for IBC denom")
+
+	_, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAphoton.Base)
+	suite.Require().False(found, "only deploy VFBC for IBC denom")
+
+	vfbcIbcAtomAddr, found := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcAtom.Base)
+	suite.Require().True(found)
+	suite.Require().Equal(originalVfbcIbcAtomAddr, vfbcIbcAtomAddr, "address must not be changed")
+
+	vfbcIbcOsmoAddr, found := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcOsmo.Base)
+	suite.Require().True(found)
+	suite.Require().Equal(originalVfbcIbcOsmoAddr, vfbcIbcOsmoAddr, "address must not be changed")
+
+	vfbcIbcAtom := suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcAtomAddr)
+	suite.Require().NotNil(vfbcIbcAtom)
+	suite.Require().Equal(originalVfbcIbcAtom, vfbcIbcAtom, "content must not be changed")
+
+	vfbcIbcOsmo := suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcOsmoAddr)
+	suite.Require().NotNil(vfbcIbcOsmo)
+	suite.Require().Equal(originalVfbcIbcOsmo, vfbcIbcOsmo, "content must not be changed")
+
+	/* ------------------------- call epoch hook again with different epoch identifier ------------------------- */
+
+	err = hooks.BeforeEpochStart(suite.Ctx, "month", 0)
+	suite.Require().NoError(err)
+
+	_, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAdym.Base)
+	suite.Require().False(found, "only deploy VFBC for IBC denom")
+
+	_, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomAphoton.Base)
+	suite.Require().False(found, "only deploy VFBC for IBC denom")
+
+	vfbcIbcAtomAddr, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcAtom.Base)
+	suite.Require().True(found)
+	suite.Require().Equal(originalVfbcIbcAtomAddr, vfbcIbcAtomAddr, "address must not be changed")
+
+	vfbcIbcOsmoAddr, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcOsmo.Base)
+	suite.Require().True(found)
+	suite.Require().Equal(originalVfbcIbcOsmoAddr, vfbcIbcOsmoAddr, "address must not be changed")
+
+	vfbcIbcAtom = suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcAtomAddr)
+	suite.Require().NotNil(vfbcIbcAtom)
+	suite.Require().Equal(originalVfbcIbcAtom, vfbcIbcAtom, "content must not be changed")
+
+	vfbcIbcOsmo = suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcOsmoAddr)
+	suite.Require().NotNil(vfbcIbcOsmo)
+	suite.Require().Equal(originalVfbcIbcOsmo, vfbcIbcOsmo, "content must not be changed")
+
+	/* ------------------------- deploy new contract ------------------------- */
+
+	denomIbcEvmos := createDenomMetadata("ibc/aevmos", "EVMOS", 18)
+	suite.Require().Nil(denomIbcEvmos.Validate(), "bad setup")
+	suite.App.BankKeeper.SetDenomMetaData(suite.Ctx, denomIbcEvmos)
+
+	err = hooks.BeforeEpochStart(suite.Ctx, epochIdentifier, 0)
+	suite.Require().NoError(err)
+
+	vfbcIbcAtomAddr, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcAtom.Base)
+	suite.Require().True(found)
+
+	vfbcIbcOsmoAddr, found = suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcOsmo.Base)
+	suite.Require().True(found)
+
+	vfbcIbcEvmosAddr, found := suite.App.EvmKeeper.GetVirtualFrontierBankContractAddressByDenom(suite.Ctx, denomIbcEvmos.Base)
+	suite.Require().True(found)
+
+	vfbcIbcAtom = suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcAtomAddr)
+	suite.Require().NotNil(vfbcIbcAtom)
+	suite.Require().Equal(originalVfbcIbcAtom, vfbcIbcAtom, "content must not be changed")
+
+	vfbcIbcOsmo = suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, originalVfbcIbcOsmoAddr)
+	suite.Require().NotNil(vfbcIbcOsmo)
+	suite.Require().Equal(originalVfbcIbcOsmo, vfbcIbcOsmo, "content must not be changed")
+
+	vfbcIbcEvmos := suite.App.EvmKeeper.GetVirtualFrontierContract(suite.Ctx, vfbcIbcEvmosAddr)
+	suite.Require().NotNil(vfbcIbcEvmos)
+
+	suite.Require().NotEqual(vfbcIbcAtomAddr, vfbcIbcEvmosAddr, "contract addresses must be different")
+	suite.Require().NotEqual(vfbcIbcOsmoAddr, vfbcIbcEvmosAddr, "contract addresses must be different")
+
+	/* ------------------------- ensure contract content ------------------------- */
+
+	accountContractIbcAtom := suite.App.EvmKeeper.GetAccount(suite.Ctx, vfbcIbcAtomAddr)
+	suite.Require().NotNil(accountContractIbcAtom)
+	suite.Require().NotEmpty(accountContractIbcAtom.CodeHash)
+	suite.Equal(uint64(1), accountContractIbcAtom.Nonce)
+
+	accountContractIbcOsmo := suite.App.EvmKeeper.GetAccount(suite.Ctx, vfbcIbcOsmoAddr)
+	suite.Require().NotNil(accountContractIbcOsmo)
+	suite.Require().NotEmpty(accountContractIbcOsmo.CodeHash)
+	suite.Equal(uint64(1), accountContractIbcOsmo.Nonce)
+
+	accountContractIbcEvmos := suite.App.EvmKeeper.GetAccount(suite.Ctx, vfbcIbcEvmosAddr)
+	suite.Require().NotNil(accountContractIbcEvmos)
+	suite.Require().NotEmpty(accountContractIbcEvmos.CodeHash)
+	suite.Equal(uint64(1), accountContractIbcEvmos.Nonce)
+
+	if suite.Equal(accountContractIbcAtom.CodeHash, accountContractIbcOsmo.CodeHash) &&
+		suite.Equal(accountContractIbcAtom.CodeHash, accountContractIbcEvmos.CodeHash) {
+		// Currently DYM does not use EthAccount is the default proto account so the following test won't work.
+		// TODO: In the future, if enable contract creation for DYM, need to migrate all the VFBC to use EthAccount and set the corresponding code hash and code.
+		/*
+			suite.NotEmpty(suite.App.EvmKeeper.GetCode(suite.Ctx, common.BytesToHash(accountContractIbcAtom.CodeHash)))
+			suite.NotEmpty(suite.App.EvmKeeper.GetCode(suite.Ctx, common.BytesToHash(accountContractIbcOsmo.CodeHash)))
+			suite.NotEmpty(suite.App.EvmKeeper.GetCode(suite.Ctx, common.BytesToHash(accountContractIbcEvmos.CodeHash)))
+
+			expectedCodeHash := []byte{242, 212, 238, 130, 251, 7, 113, 156, 203, 245, 205, 60, 34, 40, 221, 251, 24, 166, 103, 255, 59, 173, 19, 34, 43, 190, 198, 94, 101, 40, 4, 154}
+			if !suite.Equal(expectedCodeHash, accountContractIbcAtom.CodeHash) {
+				suite.NotEqual(crypto.Keccak256(nil), accountContractIbcAtom.CodeHash, "code hash must not be empty")
+			}
+		*/
+	}
+}
+
+func createDenomMetadata(base, display string, decimals uint32) banktypes.Metadata {
+	return banktypes.Metadata{
+		Description: display,
+		DenomUnits: []*banktypes.DenomUnit{
+			{
+				Denom:    base,
+				Exponent: 0,
+			},
+			{
+				Denom:    display,
+				Exponent: decimals,
+			},
+		},
+		Base:    base,
+		Display: display,
+		Name:    display,
+		Symbol:  display,
+	}
+}

--- a/x/evm/keeper/epoch_hooks_test.go
+++ b/x/evm/keeper/epoch_hooks_test.go
@@ -2,7 +2,7 @@ package keeper_test
 
 import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	extended_evm_keeper "github.com/dymensionxyz/dymension/v3/x/evm/keeper"
+	extendedevmkeeper "github.com/dymensionxyz/dymension/v3/x/evm/keeper"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/suite"
 )
@@ -30,7 +30,7 @@ func (suite *KeeperTestSuite) TestHookOperation_BeforeEpochStart() {
 
 	const epochIdentifier = "day"
 
-	hooks := extended_evm_keeper.NewEvmEpochHooks(*suite.App.EvmKeeper, suite.App.BankKeeper)
+	hooks := extendedevmkeeper.NewEvmEpochHooks(*suite.App.EvmKeeper, suite.App.BankKeeper)
 
 	suite.Ctx = suite.Ctx.WithBlockHeight(0) // ignore invoking x/evm exec for contract deployment
 
@@ -179,7 +179,7 @@ func (suite *KeeperTestSuite) TestHookOperation_BeforeEpochStart() {
 	if suite.Equal(accountContractIbcAtom.CodeHash, accountContractIbcOsmo.CodeHash) &&
 		suite.Equal(accountContractIbcAtom.CodeHash, accountContractIbcEvmos.CodeHash) {
 		// Currently DYM does not use EthAccount is the default proto account so the following test won't work.
-		// TODO: In the future, if enable contract creation for DYM, need to migrate all the VFBC to use EthAccount and set the corresponding code hash and code.
+		// TODO: In the future, if enable contract creation for DYM, need to migrate all the VFBC to use EthAccount and set the corresponding code hash and code, see https://github.com/VictorTrustyDev/fork-dym-ethermint/blob/0baa0fd7c351cf91356788450acb20e42ebd6366/x/evm/keeper/virtual_frontier_contract.go#L289-L290
 		/*
 			suite.NotEmpty(suite.App.EvmKeeper.GetCode(suite.Ctx, common.BytesToHash(accountContractIbcAtom.CodeHash)))
 			suite.NotEmpty(suite.App.EvmKeeper.GetCode(suite.Ctx, common.BytesToHash(accountContractIbcOsmo.CodeHash)))

--- a/x/evm/keeper/suite_test.go
+++ b/x/evm/keeper/suite_test.go
@@ -1,0 +1,22 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/osmosis-labs/osmosis/v15/app/apptesting"
+)
+
+type KeeperTestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+// SetupTest sets streamer parameters from the suite's context
+func (suite *KeeperTestSuite) SetupTest() {
+	suite.Setup()
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}


### PR DESCRIPTION
Closes: #627

For the detailed information about the VFC, visit: https://github.com/dymensionxyz/ethermint/pull/11.
This PR integrate the feature into Dymension Hub.

Features:
- Virtual Frontier Bank Contract
- Auto deploy contract
  - For Dymension chains at begin epoch **day**, for IBC denom only (default)
  - For local-net, at block 1, for native denom

Incompatible issue:
- Dymension uses default proto of Cosmos, which is BaseAccount, not Ethermint's default is EthAccount so the expected VFBC contract code hash can not be set, leading to loss of mapping to the deployed bytecode.
  - The problem was solved by this [work around](https://github.com/dymensionxyz/ethermint/pull/11/commits/f5ecd0f9d6e44ba51299a07fc781f03ea5c2f2c8)
  - Currently still work without problem but unsure.
  - **TODO: In the future, if enable contract creation for DYM, need to migrate all the VFBC to use EthAccount and set the corresponding code hash and code.**

TODO:
- Upgrade Ethermint version upon [PR](https://github.com/dymensionxyz/ethermint/pull/11) merged.
- Generate swagger.
- Consider remove [this method](https://github.com/dymensionxyz/dymension/blob/eedd4102e1416aa16ad69a02b6b415ceab956ce1/x/evm/keeper/epoch_hooks.go#L58-L65), was added for testing purpose.