### PR TITLE
feat: rollapp ibc state validation upon state update 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -619,6 +619,7 @@ func New(
 		keys[delayedacktypes.MemStoreKey],
 		app.GetSubspace(delayedacktypes.ModuleName),
 		app.RollappKeeper,
+		app.SequencerKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ConnectionKeeper,

--- a/ibctesting/delayed_ack_test.go
+++ b/ibctesting/delayed_ack_test.go
@@ -98,6 +98,8 @@ func (suite *DelayedAckTestSuite) TestTransferRollappToHubNotFinalized() {
 	hubIBCKeeper := suite.hubChain.App.GetIBCKeeper()
 
 	suite.CreateRollapp()
+	suite.RegisterSequencer()
+	suite.UpdateRollappState(1, uint64(suite.rollappChain.GetContext().BlockHeight()))
 
 	timeoutHeight := clienttypes.NewHeight(100, 110)
 	amount, ok := sdk.NewIntFromString("10000000000000000000") //10DYM
@@ -130,6 +132,7 @@ func (suite *DelayedAckTestSuite) TestTransferRollappToHubFinalization() {
 	rollappIBCKeeper := suite.rollappChain.App.GetIBCKeeper()
 
 	suite.CreateRollapp()
+	suite.RegisterSequencer()
 
 	// Upate rollapp state
 	currentRollappBlockHeight := uint64(suite.rollappChain.GetContext().BlockHeight())
@@ -177,6 +180,7 @@ func (suite *DelayedAckTestSuite) TestHubToRollappTimeout() {
 	hubIBCKeeper := suite.hubChain.App.GetIBCKeeper()
 	// Create rollapp and update its initial state
 	suite.CreateRollapp()
+	suite.RegisterSequencer()
 	suite.UpdateRollappState(1, uint64(suite.rollappChain.GetContext().BlockHeight()))
 	// Set the timeout height
 	timeoutHeight := clienttypes.GetSelfHeight(suite.rollappChain.GetContext())

--- a/ibctesting/denom_metadata_test.go
+++ b/ibctesting/denom_metadata_test.go
@@ -36,7 +36,7 @@ func (suite *DenomMetaDataTestSuite) TestDenomRegistationRollappToHub() {
 
 	//register rollapp with metadata for stake denom
 	suite.CreateRollappWithMetadata(sdk.DefaultBondDenom)
-
+	suite.RegisterSequencer()
 	// Finalize the rollapp 100 blocks later so all packets are received immediately
 	currentRollappBlockHeight := uint64(suite.rollappChain.GetContext().BlockHeight())
 	suite.UpdateRollappState(1, currentRollappBlockHeight)

--- a/ibctesting/eibc_test.go
+++ b/ibctesting/eibc_test.go
@@ -2,7 +2,6 @@ package ibctesting_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -136,7 +135,6 @@ func (suite *EIBCTestSuite) TestEIBCDemandOrderCreation() {
 			}
 			eibcJson, _ := json.Marshal(memoObj)
 			memo := string(eibcJson)
-			fmt.Println(tc.name)
 			_ = suite.TransferRollappToHub(path, IBCSenderAccount, tc.recipient, tc.amount, memo, tc.isAckError)
 			// Validate demand orders results
 			eibcKeeper := ConvertToApp(suite.hubChain).EIBCKeeper
@@ -330,6 +328,7 @@ func (suite *EIBCTestSuite) TestTimeoutEIBCDemandOrderFulfillment() {
 	hubIBCKeeper := suite.hubChain.App.GetIBCKeeper()
 	// Create rollapp and update its initial state
 	suite.CreateRollapp()
+	suite.RegisterSequencer()
 	suite.UpdateRollappState(1, uint64(suite.rollappChain.GetContext().BlockHeight()))
 	// Set the timeout height
 	timeoutHeight := clienttypes.GetSelfHeight(suite.rollappChain.GetContext())
@@ -430,8 +429,6 @@ func (suite *EIBCTestSuite) TransferRollappToHub(path *ibctesting.Path, sender s
 
 	// If ack error that an ack is retuned immediately hence found. The reason we get err in the relay packet is
 	// beacuse no ack can be parsed from events
-	//suite.Require().Error(err)
-	fmt.Println(err, isAckError)
 	if isAckError {
 		suite.Require().NoError(err)
 		found := hubIBCKeeper.ChannelKeeper.HasPacketAcknowledgement(hubEndpoint.Chain.GetContext(), packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())

--- a/testutil/keeper/delayedack.go
+++ b/testutil/keeper/delayedack.go
@@ -69,6 +69,10 @@ func (ConnectionKeeperStub) GetClientState(ctx sdk.Context, clientID string) (ex
 	return nil, false
 }
 
+func (ConnectionKeeperStub) GetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) (exported.ConsensusState, bool) {
+	return nil, false
+}
+
 func (ConnectionKeeperStub) GetConnection(ctx sdk.Context, connectionID string) (connectiontypes.ConnectionEnd, bool) {
 	return connectiontypes.ConnectionEnd{}, false
 }
@@ -85,6 +89,14 @@ func (RollappKeeperStub) GetRollapp(ctx sdk.Context, chainID string) (rollapptyp
 
 func (RollappKeeperStub) StateInfo(c context.Context, req *rollapptypes.QueryGetStateInfoRequest) (*rollapptypes.QueryGetStateInfoResponse, error) {
 	return nil, nil
+}
+
+func (RollappKeeperStub) GetStateInfo(ctx sdk.Context, rollappId string, index uint64) (val rollapptypes.StateInfo, found bool) {
+	return rollapptypes.StateInfo{}, false
+}
+
+func (RollappKeeperStub) GetLatestStateInfoIndex(ctx sdk.Context, rollappId string) (val rollapptypes.StateInfoIndex, found bool) {
+	return rollapptypes.StateInfoIndex{}, false
 }
 
 func DelayedackKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {

--- a/testutil/keeper/delayedack.go
+++ b/testutil/keeper/delayedack.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dymensionxyz/dymension/v3/x/delayedack/keeper"
 	"github.com/dymensionxyz/dymension/v3/x/delayedack/types"
 	rollapptypes "github.com/dymensionxyz/dymension/v3/x/rollapp/types"
+	sequencertypes "github.com/dymensionxyz/dymension/v3/x/sequencer/types"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -99,6 +100,13 @@ func (RollappKeeperStub) GetLatestStateInfoIndex(ctx sdk.Context, rollappId stri
 	return rollapptypes.StateInfoIndex{}, false
 }
 
+type SequencerKeeperStub struct{}
+
+func (SequencerKeeperStub) GetSequencer(ctx sdk.Context, sequencerAddress string) (val sequencertypes.Sequencer, found bool) {
+	return sequencertypes.Sequencer{}, false
+
+}
+
 func DelayedackKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
@@ -125,6 +133,7 @@ func DelayedackKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 		memStoreKey,
 		paramsSubspace,
 		RollappKeeperStub{},
+		SequencerKeeperStub{},
 		ICS4WrapperStub{},
 		ChannelKeeperStub{},
 		ClientKeeperStub{},

--- a/testutil/mockpv/mockpv.go
+++ b/testutil/mockpv/mockpv.go
@@ -1,0 +1,51 @@
+package mockpv
+
+import (
+	"github.com/tendermint/tendermint/crypto"
+
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cmtproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	cmttypes "github.com/tendermint/tendermint/types"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+)
+
+var _ cmttypes.PrivValidator = PV{}
+
+// PV implements PrivValidator without any safety or persistence.
+// Only use it for testing.
+type PV struct {
+	PrivKey cryptotypes.PrivKey
+}
+
+func NewPV() PV {
+	return PV{secp256k1.GenPrivKey()}
+}
+
+// GetPubKey implements PrivValidator interface
+func (pv PV) GetPubKey() (crypto.PubKey, error) {
+	return cryptocodec.ToTmPubKeyInterface(pv.PrivKey.PubKey())
+}
+
+// SignVote implements PrivValidator interface
+func (pv PV) SignVote(chainID string, vote *cmtproto.Vote) error {
+	signBytes := cmttypes.VoteSignBytes(chainID, vote)
+	sig, err := pv.PrivKey.Sign(signBytes)
+	if err != nil {
+		return err
+	}
+	vote.Signature = sig
+	return nil
+}
+
+// SignProposal implements PrivValidator interface
+func (pv PV) SignProposal(chainID string, proposal *cmtproto.Proposal) error {
+	signBytes := cmttypes.ProposalSignBytes(chainID, proposal)
+	sig, err := pv.PrivKey.Sign(signBytes)
+	if err != nil {
+		return err
+	}
+	proposal.Signature = sig
+	return nil
+}

--- a/x/delayedack/ibc_middleware.go
+++ b/x/delayedack/ibc_middleware.go
@@ -128,6 +128,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
+		return channeltypes.NewErrorAcknowledgement(err)
 	}
 
 	proofHeight, err := im.GetProofHeight(ctx, packet)
@@ -194,6 +195,7 @@ func (im IBCMiddleware) OnAcknowledgementPacket(
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
+		return err
 	}
 
 	proofHeight, err := im.GetProofHeight(ctx, packet)
@@ -263,6 +265,7 @@ func (im IBCMiddleware) OnTimeoutPacket(
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
+		return err
 	}
 
 	proofHeight, err := im.GetProofHeight(ctx, packet)

--- a/x/delayedack/ibc_middleware.go
+++ b/x/delayedack/ibc_middleware.go
@@ -2,7 +2,6 @@ package delayedack
 
 import (
 	"errors"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
@@ -44,7 +43,6 @@ func (im IBCMiddleware) OnChanOpenInit(
 	counterparty channeltypes.Counterparty,
 	version string,
 ) (string, error) {
-	fmt.Println("Openning channel ", portID, channelID, order)
 	return im.app.OnChanOpenInit(ctx, order, connectionHops, portID, channelID,
 		chanCap, counterparty, version)
 }

--- a/x/delayedack/ibc_middleware.go
+++ b/x/delayedack/ibc_middleware.go
@@ -126,6 +126,7 @@ func (im IBCMiddleware) OnRecvPacket(
 		logger.Debug("Skipping IBC transfer OnRecvPacket for non-rollapp chain")
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}
+
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.GetDestPort(), packet.GetDestChannel())
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
@@ -192,7 +193,6 @@ func (im IBCMiddleware) OnAcknowledgementPacket(
 		logger.Debug("Skipping IBC transfer OnAcknowledgementPacket for non-rollapp chain")
 		return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 	}
-
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.GetDestPort(), packet.GetDestChannel())
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
@@ -257,7 +257,6 @@ func (im IBCMiddleware) OnTimeoutPacket(
 		logger.Error("Failed to extract rollapp id from channel", "err", err)
 		return err
 	}
-	logger.Error("validation on OnTimeoutPacket")
 
 	if rollappID == "" {
 		logger.Debug("Skipping IBC transfer OnTimeoutPacket for non-rollapp chain")

--- a/x/delayedack/ibc_middleware.go
+++ b/x/delayedack/ibc_middleware.go
@@ -125,6 +125,11 @@ func (im IBCMiddleware) OnRecvPacket(
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}
 
+	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
+	if err != nil {
+		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
+	}
+
 	proofHeight, err := im.GetProofHeight(ctx, packet)
 	if err != nil {
 		logger.Error("Failed to get proof height from packet", "err", err)
@@ -184,6 +189,11 @@ func (im IBCMiddleware) OnAcknowledgementPacket(
 	if rollappID == "" {
 		logger.Debug("Skipping IBC transfer OnAcknowledgementPacket for non-rollapp chain")
 		return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
+	}
+
+	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
+	if err != nil {
+		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
 	}
 
 	proofHeight, err := im.GetProofHeight(ctx, packet)
@@ -254,6 +264,7 @@ func (im IBCMiddleware) OnTimeoutPacket(
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
 	}
+
 	proofHeight, err := im.GetProofHeight(ctx, packet)
 	if err != nil {
 		logger.Error("Failed to get proof height from packet", "err", err)

--- a/x/delayedack/ibc_middleware.go
+++ b/x/delayedack/ibc_middleware.go
@@ -126,12 +126,8 @@ func (im IBCMiddleware) OnRecvPacket(
 		logger.Debug("Skipping IBC transfer OnRecvPacket for non-rollapp chain")
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}
-	fmt.Println("validation on OnRecvPacket")
-
-	fmt.Println(packet.GetSourcePort(), packet.GetDestPort(), packet.GetDestChannel(), packet.GetSourceChannel())
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.GetDestPort(), packet.GetDestChannel())
 	if err != nil {
-		fmt.Println("Failed to validate rollappID ", rollappID)
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
@@ -196,9 +192,8 @@ func (im IBCMiddleware) OnAcknowledgementPacket(
 		logger.Debug("Skipping IBC transfer OnAcknowledgementPacket for non-rollapp chain")
 		return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 	}
-	fmt.Println("validation on OnAcknowledgementPacket")
 
-	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
+	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.GetDestPort(), packet.GetDestChannel())
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
 		return err
@@ -262,12 +257,13 @@ func (im IBCMiddleware) OnTimeoutPacket(
 		logger.Error("Failed to extract rollapp id from channel", "err", err)
 		return err
 	}
+	logger.Error("validation on OnTimeoutPacket")
 
 	if rollappID == "" {
 		logger.Debug("Skipping IBC transfer OnTimeoutPacket for non-rollapp chain")
 		return im.app.OnTimeoutPacket(ctx, packet, relayer)
 	}
-	fmt.Println("validation on timeout")
+
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)

--- a/x/delayedack/ibc_middleware.go
+++ b/x/delayedack/ibc_middleware.go
@@ -250,12 +250,15 @@ func (im IBCMiddleware) OnTimeoutPacket(
 		return im.app.OnTimeoutPacket(ctx, packet, relayer)
 	}
 
+	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
+	if err != nil {
+		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
+	}
 	proofHeight, err := im.GetProofHeight(ctx, packet)
 	if err != nil {
 		logger.Error("Failed to get proof height from packet", "err", err)
 		return err
 	}
-
 	finalized, err := im.CheckIfFinalized(ctx, rollappID, proofHeight)
 	if err != nil {
 		logger.Error("Failed to check if packet is finalized", "err", err)

--- a/x/delayedack/ibc_middleware.go
+++ b/x/delayedack/ibc_middleware.go
@@ -2,6 +2,7 @@ package delayedack
 
 import (
 	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
@@ -43,6 +44,7 @@ func (im IBCMiddleware) OnChanOpenInit(
 	counterparty channeltypes.Counterparty,
 	version string,
 ) (string, error) {
+	fmt.Println("Openning channel ", portID, channelID, order)
 	return im.app.OnChanOpenInit(ctx, order, connectionHops, portID, channelID,
 		chanCap, counterparty, version)
 }
@@ -124,9 +126,12 @@ func (im IBCMiddleware) OnRecvPacket(
 		logger.Debug("Skipping IBC transfer OnRecvPacket for non-rollapp chain")
 		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}
+	fmt.Println("validation on OnRecvPacket")
 
-	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
+	fmt.Println(packet.GetSourcePort(), packet.GetDestPort(), packet.GetDestChannel(), packet.GetSourceChannel())
+	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.GetDestPort(), packet.GetDestChannel())
 	if err != nil {
+		fmt.Println("Failed to validate rollappID ", rollappID)
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)
 		return channeltypes.NewErrorAcknowledgement(err)
 	}
@@ -191,6 +196,7 @@ func (im IBCMiddleware) OnAcknowledgementPacket(
 		logger.Debug("Skipping IBC transfer OnAcknowledgementPacket for non-rollapp chain")
 		return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 	}
+	fmt.Println("validation on OnAcknowledgementPacket")
 
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
 	if err != nil {
@@ -261,7 +267,7 @@ func (im IBCMiddleware) OnTimeoutPacket(
 		logger.Debug("Skipping IBC transfer OnTimeoutPacket for non-rollapp chain")
 		return im.app.OnTimeoutPacket(ctx, packet, relayer)
 	}
-
+	fmt.Println("validation on timeout")
 	err = im.keeper.ValidateRollappId(ctx, rollappID, packet.DestinationPort, packet.DestinationChannel)
 	if err != nil {
 		logger.Error("Failed to validate rollappID", "rollappID", rollappID, "err", err)

--- a/x/delayedack/keeper/keeper.go
+++ b/x/delayedack/keeper/keeper.go
@@ -186,7 +186,6 @@ func (k *Keeper) GetAppVersion(
 func (k *Keeper) LookupModuleByChannel(ctx sdk.Context, portID, channelID string) (string, *capabilitytypes.Capability, error) {
 	return k.channelKeeper.LookupModuleByChannel(ctx, portID, channelID)
 }
-
 func (k *Keeper) ValidateRollappId(ctx sdk.Context, rollapp, portID, channelID string) error {
 
 	// Get the rollapp state latest height and compare it to the client state height.
@@ -203,8 +202,9 @@ func (k *Keeper) ValidateRollappId(ctx sdk.Context, rollapp, portID, channelID s
 	}
 
 	// Compare the validators set hash of the consensus state to the sequencer hash.
-	// We take the previous height as we compare it against the next validator hash of previous block.
-	//previousRollappStateHeight := stateInfo.StartHeight - 1
+	// TODO (srene): We compare the validator set of the last consensus height, because it fails to  get consensus for a different height,
+	// but we should compare the validator set at the height of the last state info, because sequencer may have changed after that.
+	// If the sequencer is changed, then the validation will faill till the new sequencer sends a new state info update.
 	tmConsensusState, err := k.getTmConsensusState(ctx, portID, channelID)
 	if err != nil {
 		k.Logger(ctx).Error("error consensus state", err)

--- a/x/delayedack/keeper/keeper.go
+++ b/x/delayedack/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -15,8 +16,10 @@ import (
 	porttypes "github.com/cosmos/ibc-go/v6/modules/core/05-port/types"
 	"github.com/cosmos/ibc-go/v6/modules/core/exported"
 	ibctypes "github.com/cosmos/ibc-go/v6/modules/light-clients/07-tendermint/types"
+	tenderminttypes "github.com/cosmos/ibc-go/v6/modules/light-clients/07-tendermint/types"
 	"github.com/dymensionxyz/dymension/v3/x/delayedack/types"
 	rollapptypes "github.com/dymensionxyz/dymension/v3/x/rollapp/types"
+	sequencertypes "github.com/dymensionxyz/dymension/v3/x/sequencer/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
 
@@ -29,6 +32,7 @@ type (
 		paramstore paramtypes.Subspace
 
 		rollappKeeper    types.RollappKeeper
+		sequencerKeeper  types.SequencerKeeper
 		ics4Wrapper      porttypes.ICS4Wrapper
 		channelKeeper    types.ChannelKeeper
 		connectionKeeper types.ConnectionKeeper
@@ -110,21 +114,15 @@ func (k Keeper) GetRollappFinalizedHeight(ctx sdk.Context, chainID string) (uint
 }
 
 // GetClientState retrieves the client state for a given packet.
-func (k Keeper) GetClientState(ctx sdk.Context, packet channeltypes.Packet) (exported.ClientState, error) {
-	channel, found := k.channelKeeper.GetChannel(ctx, packet.DestinationPort, packet.DestinationChannel)
-	if !found {
-		return nil, sdkerrors.Wrap(channeltypes.ErrChannelNotFound, packet.SourceChannel)
+func (k Keeper) GetClientState(ctx sdk.Context, portID string, channelID string) (exported.ClientState, error) {
+	connectionEnd, err := k.GetConnectionEnd(ctx, portID, channelID)
+	if err != nil {
+		return nil, err
 	}
-	connectionEnd, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
-	if !found {
-		return nil, sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
-	}
-
 	clientState, found := k.clientKeeper.GetClientState(ctx, connectionEnd.GetClientID())
 	if !found {
 		return nil, clienttypes.ErrConsensusStateNotFound
 	}
-
 	return clientState, nil
 }
 
@@ -184,4 +182,89 @@ func (k *Keeper) GetAppVersion(
 // LookupModuleByChannel wraps ChannelKeeper LookupModuleByChannel function.
 func (k *Keeper) LookupModuleByChannel(ctx sdk.Context, portID, channelID string) (string, *capabilitytypes.Capability, error) {
 	return k.channelKeeper.LookupModuleByChannel(ctx, portID, channelID)
+}
+
+func (k *Keeper) ValidateRollappId(ctx sdk.Context, rollapp, portID, channelID string) error {
+
+	// Get the rollapp state latest height and compare it to the client state height.
+	// As the assumption the sequencer is honest we don't check the packet proof height.
+	// Another assumption here is that the clientstate height >= rollapp state height as
+	// the client state is updated directly while the rollapp state is updated every batch interval.
+	latestStateIndex, found := k.rollappKeeper.GetLatestStateInfoIndex(ctx, rollapp)
+	if !found {
+		return sdkerrors.Wrapf(rollapptypes.ErrUnknownRollappID, "state info not found for the rollapp: %s", rollapp)
+	}
+	stateInfo, found := k.rollappKeeper.GetStateInfo(ctx, rollapp, latestStateIndex.Index)
+	if !found {
+		return sdkerrors.Wrapf(rollapptypes.ErrUnknownRollappID, "state info not found for the rollapp: %s with index: %d", rollapp, latestStateIndex.Index)
+	}
+	// Get the tm consensus state for the channel for the rollapp state height
+	tmConsensusState, err := k.getTmConsensusStateForChannelAndHeight(ctx, portID, channelID, stateInfo.StartHeight)
+	if err != nil {
+		return err
+	}
+	// Compare the consensus state to the rollapp state. We assume the first BD is for the start height.
+	rollappStateRoot := stateInfo.BDs.BD[0].StateRoot
+	consensusStateRoot := tmConsensusState.GetRoot().GetHash()
+	if !bytes.Equal(consensusStateRoot, rollappStateRoot) {
+		errMsg := fmt.Sprintf("consensus state does not match the rollapp state at height %d: client root %x, rollapp root %x",
+			stateInfo.StartHeight, consensusStateRoot, rollappStateRoot)
+		return sdkerrors.Wrap(types.ErrMismatchedStateRoots, errMsg)
+	}
+	// Compare the validators set hash of the consensus state to the sequencer hash.
+	// We take the previous height as we compare it against the next validator hash of previous block.
+	previousRollappStateHeight := stateInfo.StartHeight - 1
+	tmConsensusState, err = k.getTmConsensusStateForChannelAndHeight(ctx, portID, channelID, previousRollappStateHeight)
+	if err != nil {
+		return err
+	}
+	sequencer, found := k.sequencerKeeper.GetSequencer(ctx, stateInfo.Sequencer)
+	if !found {
+		return sdkerrors.Wrapf(sequencertypes.ErrUnknownSequencer, "sequencer %s not found for the rollapp %s", stateInfo.Sequencer, rollapp)
+	}
+	seqPubKeyHash, err := sequencer.GetDymintPubKeyHash()
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(tmConsensusState.NextValidatorsHash, seqPubKeyHash) {
+		errMsg := fmt.Sprintf("consensus state does not match the rollapp state at height %d: consensus state validators %x, rollapp sequencer %x",
+			previousRollappStateHeight, tmConsensusState.NextValidatorsHash, stateInfo.Sequencer)
+		return sdkerrors.Wrap(types.ErrMismatchedSequencer, errMsg)
+	}
+	return nil
+}
+
+func (k Keeper) GetConnectionEnd(ctx sdk.Context, portID string, channelID string) (connectiontypes.ConnectionEnd, error) {
+	channel, found := k.channelKeeper.GetChannel(ctx, portID, channelID)
+	if !found {
+		return connectiontypes.ConnectionEnd{}, sdkerrors.Wrap(channeltypes.ErrChannelNotFound, channelID)
+	}
+	connectionEnd, found := k.connectionKeeper.GetConnection(ctx, channel.ConnectionHops[0])
+	if !found {
+		return connectiontypes.ConnectionEnd{}, sdkerrors.Wrap(connectiontypes.ErrConnectionNotFound, channel.ConnectionHops[0])
+	}
+	return connectionEnd, nil
+}
+
+// getTmConsensusStateForChannelAndHeight returns the tendermint consensus state for the channel for specific height
+func (k Keeper) getTmConsensusStateForChannelAndHeight(ctx sdk.Context, portID string, channelID string, height uint64) (*tenderminttypes.ConsensusState, error) {
+	// Get the client state for the channel for specific height
+	connectionEnd, err := k.GetConnectionEnd(ctx, portID, channelID)
+	if err != nil {
+		return &tenderminttypes.ConsensusState{}, err
+	}
+	clientState, err := k.GetClientState(ctx, portID, channelID)
+	if err != nil {
+		return &tenderminttypes.ConsensusState{}, err
+	}
+	revisionHeight := clienttypes.NewHeight(clientState.GetLatestHeight().GetRevisionNumber(), height)
+	consensusState, found := k.clientKeeper.GetClientConsensusState(ctx, connectionEnd.GetClientID(), revisionHeight)
+	if !found {
+		return nil, clienttypes.ErrConsensusStateNotFound
+	}
+	tmConsensusState, ok := consensusState.(*tenderminttypes.ConsensusState)
+	if !ok {
+		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidType, "expected tendermint consensus state, got %T", consensusState)
+	}
+	return tmConsensusState, nil
 }

--- a/x/delayedack/keeper/keeper.go
+++ b/x/delayedack/keeper/keeper.go
@@ -249,12 +249,12 @@ func (k Keeper) getTmConsensusState(ctx sdk.Context, portID string, channelID st
 	if err != nil {
 		return &tenderminttypes.ConsensusState{}, err
 	}
-	k.Logger(ctx).Error("connectionEnd", "id", connectionEnd)
 	clientState, err := k.GetClientState(ctx, portID, channelID)
 	if err != nil {
 		return &tenderminttypes.ConsensusState{}, err
 	}
-	k.Logger(ctx).Error("clientState", "id", clientState)
+
+	//TODO(srene) : consensus state is only obtained when getting it for latestheight. this can be an issue when sequencer changes. i have to figure out why is only returned for latest height
 
 	consensusState, found := k.clientKeeper.GetClientConsensusState(ctx, connectionEnd.GetClientID(), clientState.GetLatestHeight())
 	if !found {

--- a/x/delayedack/types/errors.go
+++ b/x/delayedack/types/errors.go
@@ -9,4 +9,6 @@ var (
 	ErrRollappPacketDoesNotExist  = sdkerrors.Register(ModuleName, 2, "rollapp packet does not exist")
 	ErrInvalidEIBCFee             = sdkerrors.Register(ModuleName, 3, "invalid eibc fee")
 	ErrEmptyEpochIdentifier       = sdkerrors.Register(ModuleName, 4, "empty epoch identifier")
+	ErrMismatchedStateRoots       = sdkerrors.Register(ModuleName, 5, "mismatched state roots")
+	ErrMismatchedSequencer        = sdkerrors.Register(ModuleName, 6, "mismatched sequencer")
 )

--- a/x/delayedack/types/expected_keepers.go
+++ b/x/delayedack/types/expected_keepers.go
@@ -9,8 +9,8 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
 	"github.com/cosmos/ibc-go/v6/modules/core/exported"
 	eibctypes "github.com/dymensionxyz/dymension/v3/x/eibc/types"
-	"github.com/dymensionxyz/dymension/v3/x/rollapp/types"
 	rollapptypes "github.com/dymensionxyz/dymension/v3/x/rollapp/types"
+	sequencertypes "github.com/dymensionxyz/dymension/v3/x/sequencer/types"
 )
 
 // ChannelKeeper defines the expected IBC channel keeper
@@ -22,6 +22,7 @@ type ChannelKeeper interface {
 
 type ClientKeeper interface {
 	GetClientState(ctx sdk.Context, clientID string) (exported.ClientState, bool)
+	GetClientConsensusState(ctx sdk.Context, clientID string, height exported.Height) (exported.ConsensusState, bool)
 }
 
 type ConnectionKeeper interface {
@@ -31,9 +32,14 @@ type ConnectionKeeper interface {
 type RollappKeeper interface {
 	GetParams(ctx sdk.Context) rollapptypes.Params
 	GetRollapp(ctx sdk.Context, chainID string) (rollapp rollapptypes.Rollapp, found bool)
-	StateInfo(c context.Context, req *types.QueryGetStateInfoRequest) (*types.QueryGetStateInfoResponse, error)
+	GetStateInfo(ctx sdk.Context, rollappId string, index uint64) (val rollapptypes.StateInfo, found bool)
+	StateInfo(ctx context.Context, req *rollapptypes.QueryGetStateInfoRequest) (*rollapptypes.QueryGetStateInfoResponse, error)
+	GetLatestStateInfoIndex(ctx sdk.Context, rollappId string) (val rollapptypes.StateInfoIndex, found bool)
 }
 
+type SequencerKeeper interface {
+	GetSequencer(ctx sdk.Context, sequencerAddress string) (val sequencertypes.Sequencer, found bool)
+}
 type EIBCKeeper interface {
 	SetDemandOrder(ctx sdk.Context, order *eibctypes.DemandOrder) error
 	TimeoutFee(ctx sdk.Context) sdk.Dec

--- a/x/sequencer/types/sequencer.go
+++ b/x/sequencer/types/sequencer.go
@@ -21,13 +21,17 @@ func (seq Sequencer) IsProposer() bool {
 // as expected to written on the rollapp ibc client headers
 func (seq Sequencer) GetDymintPubKeyHash() ([]byte, error) {
 	// load the dymint pubkey into a cryptotypes.PubKey
+
 	interfaceRegistry := cdctypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(interfaceRegistry)
 	protoCodec := codec.NewProtoCodec(interfaceRegistry)
+
 	var pubKey cryptotypes.PubKey
 	err := protoCodec.UnpackAny(seq.DymintPubKey, &pubKey)
 	if err != nil {
 		return nil, err
 	}
+
 	// convert the pubkey to tmPubKey
 	tmPubKey, err := cryptocodec.ToTmPubKeyInterface(pubKey)
 	if err != nil {

--- a/x/sequencer/types/sequencer.go
+++ b/x/sequencer/types/sequencer.go
@@ -1,5 +1,13 @@
 package types
 
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
 func (seq Sequencer) IsBonded() bool {
 	return seq.Status == Bonded
 }
@@ -7,4 +15,28 @@ func (seq Sequencer) IsBonded() bool {
 // is proposer
 func (seq Sequencer) IsProposer() bool {
 	return seq.Proposer
+}
+
+// GetDymintPubKeyHash returns the hash of the sequencer
+// as expected to written on the rollapp ibc client headers
+func (seq Sequencer) GetDymintPubKeyHash() ([]byte, error) {
+	// load the dymint pubkey into a cryptotypes.PubKey
+	interfaceRegistry := cdctypes.NewInterfaceRegistry()
+	protoCodec := codec.NewProtoCodec(interfaceRegistry)
+	var pubKey cryptotypes.PubKey
+	err := protoCodec.UnpackAny(seq.DymintPubKey, &pubKey)
+	if err != nil {
+		return nil, err
+	}
+	// convert the pubkey to tmPubKey
+	tmPubKey, err := cryptocodec.ToTmPubKeyInterface(pubKey)
+	if err != nil {
+		return nil, err
+	}
+	// Create a new tmValidator with fixed voting power of 1
+	// TODO: Make sure the voting power is a param coming from hub and
+	// not being set independently in dymint and hub
+	tmValidator := tmtypes.NewValidator(tmPubKey, 1)
+	tmValidatorSet := tmtypes.NewValidatorSet([]*tmtypes.Validator{tmValidator})
+	return tmValidatorSet.Hash(), nil
 }

--- a/x/sequencer/types/sequencer.go
+++ b/x/sequencer/types/sequencer.go
@@ -18,10 +18,9 @@ func (seq Sequencer) IsProposer() bool {
 }
 
 // GetDymintPubKeyHash returns the hash of the sequencer
-// as expected to written on the rollapp ibc client headers
+// as expected to be written on the rollapp ibc client headers
 func (seq Sequencer) GetDymintPubKeyHash() ([]byte, error) {
 	// load the dymint pubkey into a cryptotypes.PubKey
-
 	interfaceRegistry := cdctypes.NewInterfaceRegistry()
 	cryptocodec.RegisterInterfaces(interfaceRegistry)
 	protoCodec := codec.NewProtoCodec(interfaceRegistry)


### PR DESCRIPTION
## Description

----

The  objective of this PR is to prevent potential vector attacks that utilises other cosmos chains with the same chain id of an existing rollappid to enable malicious ibc-transfers to other chains that are not the rollapp itself.

For that, we need to prevent  that any ibc-transfer can use the chain id of an existing rollapp, without coming from the real rollapp, authenticating the rollapp id. In the following we list 3 potential solutions:

Solution 1:  Reject  channels creation with same id of rollapp id

Main drawback: it is not possible to prevent channel creations with the chain id equal to a  rollappid,  that is not yet registered in the hub, but it can be known beforehand by an attacker.

Solution 2:   Reject light clients update for a channel with a rollapp id equal to a registered rollapp id, when it does not come from the registered sequencer after the rollapp is created. By doing that, ibc will fail to accept packets from a channel that does not match rollapp sequencer info.

Main drawback: Headers received from an attacker channel until the first state info update from the valid rollapp sequencer, will be accepted as valid, being a vulnerability.

Solution 3: Checking the next validator hash in light client headers for the channel, corresponds to the same next validator hash created with a single validator, which is the sequencer registered for the rollapp in the state info.

Main drawback: The solution requires authenticating the rollapp id per ibc packet.

In this PR the solution 3 has been implemented, since even though is not the most efficient, it does not have the vulnerability issues of the first two.

Note that this is a short-term solution built with the assumptions of having a single honest sequencer for a rollapp.

Closes #643 

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x]  Targeted PR against the correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [x]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----;

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---;

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
