### PR TITLE
imp(vfc): use utility to revert dirty state since VFBC deployment no longer handle dirty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
-- (evm) [#668](https://github.com/dymensionxyz/dymension/issues/668) Integrate virtual frontier bank contract
+- (vfc) [#668](https://github.com/dymensionxyz/dymension/issues/668) Integrate virtual frontier bank contract
+- (vfc) [#736](https://github.com/dymensionxyz/dymension/issues/736) Use utility to revert dirty state since VFBC deployment no longer handle dirty state
 
 ### Bug Fixes
 

--- a/x/vfc/hooks/denom_metadata_hooks.go
+++ b/x/vfc/hooks/denom_metadata_hooks.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"github.com/osmosis-labs/osmosis/v15/osmoutils"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -25,8 +26,9 @@ func NewVirtualFrontierBankContractRegistrationHook(evmKeeper evmkeeper.Keeper) 
 func (v VirtualFrontierBankContractRegistrationHook) AfterDenomMetadataCreation(ctx sdk.Context, newDenomMetadata banktypes.Metadata) error {
 	if strings.HasPrefix(strings.ToLower(newDenomMetadata.Base), "ibc/") { // only deploy for IBC denom.
 		// Deploy the virtual frontier bank contract for the new IBC denom.
-		// Error, if any, no state transition will be made.
-		_ = v.evmKeeper.DeployVirtualFrontierBankContractForBankDenomMetadataRecord(ctx, newDenomMetadata.Base)
+		_ = osmoutils.ApplyFuncIfNoError(ctx, func(ctx sdk.Context) error {
+			return v.evmKeeper.DeployVirtualFrontierBankContractForBankDenomMetadataRecord(ctx, newDenomMetadata.Base)
+		})
 	}
 
 	return nil


### PR DESCRIPTION
## Description
@mtsitrin asked to changed the behavior:
- Deployment method should not handle revert dirty state itself.
- It's caller responsibility to handle revert dirty state.

TODO:
- [ ] Wait for merge [PR](https://github.com/dymensionxyz/ethermint/pull/15)
- [ ] Create tag for Ethermint
- [ ] Update new tag to this PR