### PR TITLE
fix(rollapp): fix `RollappFinalizedStateInvariant` on fraudulent and state revert

### DIFF
--- a/x/rollapp/keeper/invariants.go
+++ b/x/rollapp/keeper/invariants.go
@@ -238,8 +238,8 @@ func RollappFinalizedStateInvariant(k Keeper) sdk.Invariant {
 					broken = true
 				}
 
-				if stateInfo.Status != commontypes.Status_FINALIZED {
-					msg += fmt.Sprintf("rollapp (%s) have stateInfo at index %d not finalized\n", rollapp.RollappId, i)
+				if stateInfo.Status != commontypes.Status_FINALIZED && stateInfo.Status != commontypes.Status_REVERTED {
+					msg += fmt.Sprintf("rollapp (%s) have stateInfo at index %d not finalized or reverted\n", rollapp.RollappId, i)
 					broken = true
 				}
 			}

--- a/x/rollapp/keeper/invariants.go
+++ b/x/rollapp/keeper/invariants.go
@@ -238,7 +238,7 @@ func RollappFinalizedStateInvariant(k Keeper) sdk.Invariant {
 					broken = true
 				}
 
-				if stateInfo.Status != commontypes.Status_FINALIZED && stateInfo.Status != commontypes.Status_REVERTED {
+				if stateInfo.Status == commontypes.Status_PENDING {
 					msg += fmt.Sprintf("rollapp (%s) have stateInfo at index %d not finalized or reverted\n", rollapp.RollappId, i)
 					broken = true
 				}

--- a/x/rollapp/keeper/invariants_test.go
+++ b/x/rollapp/keeper/invariants_test.go
@@ -170,3 +170,22 @@ func (suite *RollappTestSuite) TestRollappFinalizedStateInvariant() {
 		})
 	}
 }
+
+// TODO: remove this after fix and move it to the function above
+func (suite *RollappTestSuite) TestBreakRollappFinalizedStateInvariant() {
+	suite.SetupTest()
+	rollapp := suite.CreateDefaultRollapp()
+	sequencer := suite.CreateDefaultSequencer(suite.Ctx, rollapp)
+	suite.Ctx = suite.Ctx.WithBlockHeight(10)
+	_, err := suite.PostStateUpdate(suite.Ctx, rollapp, sequencer, 1, 5)
+	suite.Require().Nil(err)
+	err = suite.App.RollappKeeper.FinalizeQueue(suite.Ctx)
+	suite.Require().Nil(err)
+	suite.App.RollappKeeper.RevertPendingStates(suite.Ctx, rollapp)
+	_, err = suite.PostStateUpdate(suite.Ctx, rollapp, sequencer, 6, 5)
+	suite.Require().Nil(err)
+	err = suite.App.RollappKeeper.FinalizeQueue(suite.Ctx.WithBlockHeight(20))
+	suite.Require().Nil(err)
+	_, isBroken := keeper.RollappFinalizedStateInvariant(suite.App.RollappKeeper)(suite.Ctx)
+	suite.Require().Equal(false, isBroken)
+}


### PR DESCRIPTION
## Description

Closes #759 

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x]  Targeted PR against the correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x]  Linked to the GitHub issue with discussion and accepted design
- [x]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----;

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---;

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
