### PR TITLE
chores: remove gauge fee in upgrade handler

### DIFF
--- a/app/upgrades/v3/upgrade.go
+++ b/app/upgrades/v3/upgrade.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	appparams "github.com/dymensionxyz/dymension/v3/app/params"
-	incentivestypes "github.com/osmosis-labs/osmosis/v15/x/incentives/types"
 
 	delayedacktypes "github.com/dymensionxyz/dymension/v3/x/delayedack/types"
 	rollapptypes "github.com/dymensionxyz/dymension/v3/x/rollapp/types"
@@ -34,11 +33,6 @@ func CreateUpgradeHandler(
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 
-		// reduce the gauge creation fee and remove `add to gauge` fee
-		DYM := sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
-		incentivestypes.CreateGaugeFee = DYM.Mul(sdk.NewInt(10))
-		incentivestypes.AddToGaugeFee = sdk.ZeroInt()
-
 		// Start running the module migrations
 		logger.Debug("running module migrations ...")
 		newVM, err := mm.RunMigrations(ctx, configurator, fromVM)
@@ -57,6 +51,7 @@ func CreateUpgradeHandler(
 		rollappkeeper.SetParams(ctx, rollappParams)
 
 		// overwrite params for sequencer module due to proto change
+		DYM := sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 		seqParams := seqtypes.DefaultParams()
 		seqParams.MinBond = sdk.NewCoin(appparams.BaseDenom, DYM.Mul(sdk.NewInt(1000))) // 1000DYM
 		seqkeeper.SetParams(ctx, seqParams)

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ replace (
 	github.com/evmos/ethermint => github.com/dymensionxyz/ethermint v0.22.0-dymension-v0.4.1
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/osmosis-labs/osmosis/osmomath => github.com/dymensionxyz/osmosis/osmomath v0.0.6-dym-v0.0.1
-	github.com/osmosis-labs/osmosis/v15 => github.com/dymensionxyz/osmosis/v15 v15.2.1-0.20240310110736-a0811b5943a5
+	github.com/osmosis-labs/osmosis/v15 => github.com/dymensionxyz/osmosis/v15 v15.2.1-0.20240402094839-bd45bfc51fb6
 
 	//  broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/dymensionxyz/ethermint v0.22.0-dymension-v0.4.1 h1:J31ASxmDVm7ytjmk9T
 github.com/dymensionxyz/ethermint v0.22.0-dymension-v0.4.1/go.mod h1:O2J61ZwM0Vdms6pRa1fb43pwmCuNRctro3AB90WlOc0=
 github.com/dymensionxyz/osmosis/osmomath v0.0.6-dym-v0.0.1 h1:59ZE3Ocrn04MUpb5VJgfi24eDcnQ9VBfCSw0Mx1n7OI=
 github.com/dymensionxyz/osmosis/osmomath v0.0.6-dym-v0.0.1/go.mod h1:2idySYJxP5YfMAEeSeqD8e7fSchfsI4jn7XFHJgNUsM=
-github.com/dymensionxyz/osmosis/v15 v15.2.1-0.20240310110736-a0811b5943a5 h1:fdu2lHVWNsACjqA5A63Y8sSVV8UiIoDKjOScUDTivOc=
-github.com/dymensionxyz/osmosis/v15 v15.2.1-0.20240310110736-a0811b5943a5/go.mod h1:BHHGzl86byC0sov3EUfTzyDuIsGY//rcrek6gCOa+fw=
+github.com/dymensionxyz/osmosis/v15 v15.2.1-0.20240402094839-bd45bfc51fb6 h1:3ye0ySSIJKM/E7h+IUOBkdyrtDCWGSRnKknc3g+GmYU=
+github.com/dymensionxyz/osmosis/v15 v15.2.1-0.20240402094839-bd45bfc51fb6/go.mod h1:BHHGzl86byC0sov3EUfTzyDuIsGY//rcrek6gCOa+fw=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

----
As the `CreateGaugeFee` and `AddToGaugeFee` already changed in [this PR](https://github.com/dymensionxyz/osmosis/pull/65), we should remove it in upgrade handler.
