### PR TITLE
fix (rollapp): invariant block-height-to-finalization-queue fix for freezing rollapp

### DIFF
--- a/x/rollapp/keeper/invariants.go
+++ b/x/rollapp/keeper/invariants.go
@@ -94,14 +94,19 @@ func BlockHeightToFinalizationQueueInvariant(k Keeper) sdk.Invariant {
 			if !k.IsRollappStarted(ctx, rollapp.RollappId) {
 				continue
 			}
+
+			if rollapp.GetFrozen() {
+				continue
+			}
 			latestStateIdx, _ := k.GetLatestStateInfoIndex(ctx, rollapp.RollappId)
 			latestFinalizedStateIdx, _ := k.GetLatestFinalizedStateIndex(ctx, rollapp.RollappId)
 
 			firstUnfinalizedStateIdx := latestFinalizedStateIdx.Index + 1
 
-			// iterate over all the unfinalzied states and make sure they are in the queue
+			// iterate over all the unfinalized states and make sure they are in the queue
 			for i := firstUnfinalizedStateIdx; i <= latestStateIdx.Index; i++ {
 				stateInfo, found := k.GetStateInfo(ctx, rollapp.RollappId, i)
+
 				if !found {
 					msg += fmt.Sprintf("rollapp (%s) have no stateInfo at index %d\n", rollapp.RollappId, i)
 					broken = true


### PR DESCRIPTION
## Description

This PR is aimed at fixing an issue with the block-height-to-finalization-queue invariant, that tries to find non-finalized state infos in the blockheighttofinalization queue, but it shouldn't for frozen rollapps.

----

Closes #820 

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ]  Targeted PR against the correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----;

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---;

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
