### PR TITLE
chore(ci): don't cache installed packages in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN make build
 
 FROM alpine:3.16.1
 
-RUN apk add curl jq bash vim 
+RUN apk add --no-cache curl jq bash vim 
 
 COPY --from=go-builder /app/build/dymd /usr/local/bin/
 


### PR DESCRIPTION
https://stackoverflow.com/questions/64874133/what-does-run-apk-add-no-cache-tree-mean-in-a-dockerfile