### PR TITLE
refactor(sequencer): the bond reduction storage to be more efficient for queries

### DIFF
--- a/x/sequencer/keeper/bond_reductions.go
+++ b/x/sequencer/keeper/bond_reductions.go
@@ -11,20 +11,28 @@ import (
 )
 
 func (k Keeper) HandleBondReduction(ctx sdk.Context, currTime time.Time) {
-	unbondings := k.GetMatureDecreasingBondSequencers(ctx, currTime)
-	for _, unbonding := range unbondings {
+	bondReductionIDs := k.GetMatureDecreasingBondIDs(ctx, currTime)
+	for _, bondReductionID := range bondReductionIDs {
 		wrapFn := func(ctx sdk.Context) error {
-			return k.completeBondReduction(ctx, unbonding)
+			return k.completeBondReduction(ctx, bondReductionID)
 		}
 		err := osmoutils.ApplyFuncIfNoError(ctx, wrapFn)
 		if err != nil {
-			k.Logger(ctx).Error("reducing sequencer bond", "error", err, "sequencer", unbonding.SequencerAddress)
+			k.Logger(ctx).Error("reducing sequencer bond", "error", err, "bond reduction ID", bondReductionID)
 			continue
 		}
 	}
 }
 
-func (k Keeper) completeBondReduction(ctx sdk.Context, reduction types.BondReduction) error {
+func (k Keeper) completeBondReduction(ctx sdk.Context, bondReductionID uint64) error {
+	reduction, found := k.GetBondReduction(ctx, bondReductionID)
+	if !found {
+		return errorsmod.Wrapf(
+			types.ErrUnknownBondReduction,
+			"bond reduction ID %d not found",
+			bondReductionID,
+		)
+	}
 	seq, found := k.GetSequencer(ctx, reduction.SequencerAddress)
 	if !found {
 		return types.ErrUnknownSequencer
@@ -54,20 +62,19 @@ func (k Keeper) completeBondReduction(ctx sdk.Context, reduction types.BondReduc
 
 	seq.Tokens = seq.Tokens.Sub(reduction.DecreaseBondAmount)
 	k.SetSequencer(ctx, seq)
-	k.removeDecreasingBondQueue(ctx, reduction)
+	k.removeBondReduction(ctx, bondReductionID, reduction)
 
 	return nil
 }
 
-// GetMatureDecreasingBondSequencers returns all decreasing bond items for the given time
-func (k Keeper) GetMatureDecreasingBondSequencers(ctx sdk.Context, endTime time.Time) (unbondings []types.BondReduction) {
+// GetMatureDecreasingBondIDs returns all decreasing bond IDs for the given time
+func (k Keeper) GetMatureDecreasingBondIDs(ctx sdk.Context, endTime time.Time) (bondReductionIDs []uint64) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := store.Iterator(types.DecreasingBondQueueKey, sdk.PrefixEndBytes(types.DecreasingBondQueueByTimeKey(endTime)))
 	defer iterator.Close() // nolint: errcheck
 	for ; iterator.Valid(); iterator.Next() {
-		var b types.BondReduction
-		k.cdc.MustUnmarshal(iterator.Value(), &b)
-		unbondings = append(unbondings, b)
+		bondReductionID := sdk.BigEndianToUint64(iterator.Value())
+		bondReductionIDs = append(bondReductionIDs, bondReductionID)
 	}
 	return
 }
@@ -75,46 +82,82 @@ func (k Keeper) GetMatureDecreasingBondSequencers(ctx sdk.Context, endTime time.
 // SetDecreasingBondQueue sets the bond reduction item in the decreasing bond queue
 func (k Keeper) SetDecreasingBondQueue(ctx sdk.Context, bondReduction types.BondReduction) {
 	store := ctx.KVStore(k.storeKey)
+	bondReductionID := k.increamentDecreasingBondID(ctx)
 	b := k.cdc.MustMarshal(&bondReduction)
-
-	unbondingQueueKey := types.GetDecreasingBondQueueKey(bondReduction.SequencerAddress, bondReduction.DecreaseBondTime)
-	store.Set(unbondingQueueKey, b)
+	store.Set(types.GetDecreasingBondQueueKey(bondReduction.SequencerAddress, bondReduction.DecreaseBondTime), sdk.Uint64ToBigEndian(bondReductionID))
+	store.Set(append(types.GetDecreasingBondSequencerKey(bondReduction.SequencerAddress), sdk.Uint64ToBigEndian(bondReductionID)...), sdk.Uint64ToBigEndian(bondReductionID))
+	store.Set(types.GetDecreasingBondIndexKey(bondReductionID), b)
 }
 
-// removeDecreasingBondQueue removes the bond reduction item from the decreasing bond queue
-func (k Keeper) removeDecreasingBondQueue(ctx sdk.Context, bondReduction types.BondReduction) {
+// GetBondReduction returns the bond reduction item given bond reduction ID
+func (k Keeper) GetBondReduction(ctx sdk.Context, bondReductionID uint64) (types.BondReduction, bool) {
 	store := ctx.KVStore(k.storeKey)
-	unbondingQueueKey := types.GetDecreasingBondQueueKey(bondReduction.SequencerAddress, bondReduction.DecreaseBondTime)
-	store.Delete(unbondingQueueKey)
-}
-
-// getSequencerDecreasingBonds returns the bond reduction item given sequencer address
-func (k Keeper) getSequencerDecreasingBonds(ctx sdk.Context, sequencerAddr string) (bds []types.BondReduction) {
-	prefixKey := types.DecreasingBondQueueKey
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), prefixKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte{})
-
-	defer iterator.Close() // nolint: errcheck
-
-	for ; iterator.Valid(); iterator.Next() {
-		var bd types.BondReduction
-		k.cdc.MustUnmarshal(iterator.Value(), &bd)
-		if bd.SequencerAddress == sequencerAddr {
-			bds = append(bds, bd)
-		}
+	bz := store.Get(types.GetDecreasingBondIndexKey(bondReductionID))
+	if bz == nil {
+		return types.BondReduction{}, false
 	}
-
-	return
+	var bd types.BondReduction
+	k.cdc.MustUnmarshal(bz, &bd)
+	return bd, true
 }
 
 func (k Keeper) GetAllBondReductions(ctx sdk.Context) (bds []types.BondReduction) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.DecreasingBondQueueKey)
+	iterator := sdk.KVStorePrefixIterator(store, types.DecreasingBondIndexKey)
 	defer iterator.Close() // nolint: errcheck
 	for ; iterator.Valid(); iterator.Next() {
 		var bd types.BondReduction
 		k.cdc.MustUnmarshal(iterator.Value(), &bd)
 		bds = append(bds, bd)
 	}
+	return
+}
+
+// removeBondReduction removes the bond reduction item from the decreasing bond queue
+func (k Keeper) removeBondReduction(ctx sdk.Context, bondReductionID uint64, bondReduction types.BondReduction) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.GetDecreasingBondQueueKey(bondReduction.SequencerAddress, bondReduction.DecreaseBondTime))
+	store.Delete(append(types.GetDecreasingBondSequencerKey(bondReduction.SequencerAddress), sdk.Uint64ToBigEndian(bondReductionID)...))
+	store.Delete(types.GetDecreasingBondIndexKey(bondReductionID))
+}
+
+// getBondReductionsBySequencer returns the bond reduction item given sequencer address
+func (k Keeper) getBondReductionsBySequencer(ctx sdk.Context, sequencerAddr string) (bondReductions []types.BondReduction) {
+	bondReductionIDs := k.getBondReductionIDsBySequencer(ctx, sequencerAddr)
+	for _, bondReductionID := range bondReductionIDs {
+		bd, found := k.GetBondReduction(ctx, bondReductionID)
+		if found {
+			bondReductions = append(bondReductions, bd)
+		}
+	}
+	return
+}
+
+// getBondReductionIDsBySequencer returns the bond reduction item given sequencer address
+func (k Keeper) getBondReductionIDsBySequencer(ctx sdk.Context, sequencerAddr string) (bondReductionIDs []uint64) {
+	prefixKey := types.GetDecreasingBondSequencerKey(sequencerAddr)
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), prefixKey)
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close() // nolint: errcheck
+
+	for ; iterator.Valid(); iterator.Next() {
+		bondReductionID := sdk.BigEndianToUint64(iterator.Value())
+		bondReductionIDs = append(bondReductionIDs, bondReductionID)
+	}
+	return
+}
+
+// increamentDecreasingBondID increments the decreasing bond ID anad returns the new ID
+func (k Keeper) increamentDecreasingBondID(ctx sdk.Context) (decreasingBondID uint64) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.GetDecreasingBondIDKey())
+	if bz != nil {
+		decreasingBondID = sdk.BigEndianToUint64(bz)
+	}
+	decreasingBondID++
+
+	bz = sdk.Uint64ToBigEndian(decreasingBondID)
+	store.Set(types.GetDecreasingBondIDKey(), bz)
 	return
 }

--- a/x/sequencer/keeper/hooks_test.go
+++ b/x/sequencer/keeper/hooks_test.go
@@ -37,7 +37,7 @@ func (suite *SequencerTestSuite) TestFraudSubmittedHook() {
 	unbondMsg := types.MsgDecreaseBond{Creator: seqAddrs[0], DecreaseAmount: sdk.NewInt64Coin(bond.Denom, 10)}
 	resp, err := suite.msgServer.DecreaseBond(suite.Ctx, &unbondMsg)
 	suite.Require().NoError(err)
-	bds := keeper.GetMatureDecreasingBondSequencers(suite.Ctx, resp.GetCompletionTime())
+	bds := keeper.GetMatureDecreasingBondIDs(suite.Ctx, resp.GetCompletionTime())
 	suite.Require().Len(bds, 1)
 
 	err = keeper.RollappHooks().FraudSubmitted(suite.Ctx, rollappId, 0, proposer)
@@ -60,6 +60,6 @@ func (suite *SequencerTestSuite) TestFraudSubmittedHook() {
 	_, ok := keeper.GetProposer(suite.Ctx, rollappId)
 	suite.Require().False(ok)
 	// check if bond reduction queue is pruned
-	bds = keeper.GetMatureDecreasingBondSequencers(suite.Ctx, resp.GetCompletionTime())
+	bds = keeper.GetMatureDecreasingBondIDs(suite.Ctx, resp.GetCompletionTime())
 	suite.Require().Len(bds, 0)
 }

--- a/x/sequencer/keeper/msg_server_decrease_bond.go
+++ b/x/sequencer/keeper/msg_server_decrease_bond.go
@@ -17,7 +17,7 @@ func (k msgServer) DecreaseBond(goCtx context.Context, msg *types.MsgDecreaseBon
 	}
 
 	effectiveBond := sequencer.Tokens
-	if bds := k.getSequencerDecreasingBonds(ctx, msg.Creator); len(bds) > 0 {
+	if bds := k.getBondReductionsBySequencer(ctx, msg.Creator); len(bds) > 0 {
 		for _, bd := range bds {
 			effectiveBond = effectiveBond.Sub(bd.DecreaseBondAmount)
 		}

--- a/x/sequencer/keeper/msg_server_decrease_bond_test.go
+++ b/x/sequencer/keeper/msg_server_decrease_bond_test.go
@@ -90,10 +90,12 @@ func (suite *SequencerTestSuite) TestDecreaseBond() {
 				expectedCompletionTime := suite.Ctx.BlockHeader().Time.Add(suite.App.SequencerKeeper.UnbondingTime(suite.Ctx))
 				suite.Require().Equal(expectedCompletionTime, resp.CompletionTime)
 				// check if the unbonding is set correctly
-				unbondings := suite.App.SequencerKeeper.GetMatureDecreasingBondSequencers(suite.Ctx, expectedCompletionTime)
-				suite.Require().Len(unbondings, 1)
-				suite.Require().Equal(tc.msg.Creator, unbondings[0].SequencerAddress)
-				suite.Require().Equal(tc.msg.DecreaseAmount, unbondings[0].DecreaseBondAmount)
+				bondReductionIDs := suite.App.SequencerKeeper.GetMatureDecreasingBondIDs(suite.Ctx, expectedCompletionTime)
+				suite.Require().Len(bondReductionIDs, 1)
+				bondReduction, found := suite.App.SequencerKeeper.GetBondReduction(suite.Ctx, bondReductionIDs[0])
+				suite.Require().True(found)
+				suite.Require().Equal(tc.msg.Creator, bondReduction.SequencerAddress)
+				suite.Require().Equal(tc.msg.DecreaseAmount, bondReduction.DecreaseBondAmount)
 			}
 		})
 	}

--- a/x/sequencer/keeper/slashing_fraud_test.go
+++ b/x/sequencer/keeper/slashing_fraud_test.go
@@ -87,13 +87,13 @@ func (suite *SequencerTestSuite) TestJailBondReducingSequencer() {
 	reduceBondMsg := types.MsgDecreaseBond{Creator: seqAddr, DecreaseAmount: sdk.NewInt64Coin(bond.Denom, 10)}
 	resp, err := suite.msgServer.DecreaseBond(suite.Ctx, &reduceBondMsg)
 	suite.Require().NoError(err)
-	bondReductions := keeper.GetMatureDecreasingBondSequencers(suite.Ctx, resp.GetCompletionTime())
+	bondReductions := keeper.GetMatureDecreasingBondIDs(suite.Ctx, resp.GetCompletionTime())
 	suite.Require().Len(bondReductions, 1)
 
 	err = keeper.JailSequencerOnFraud(suite.Ctx, seqAddr)
 	suite.NoError(err)
 
-	bondReductions = keeper.GetMatureDecreasingBondSequencers(suite.Ctx, resp.GetCompletionTime())
+	bondReductions = keeper.GetMatureDecreasingBondIDs(suite.Ctx, resp.GetCompletionTime())
 	suite.Require().Len(bondReductions, 0)
 	suite.assertJailed(seqAddr)
 }

--- a/x/sequencer/keeper/unbond.go
+++ b/x/sequencer/keeper/unbond.go
@@ -147,9 +147,12 @@ func (k Keeper) unbond(ctx sdk.Context, seqAddr string, jail bool) error {
 	}
 	// in case the sequencer is currently reducing its bond, then we need to remove it from the decreasing bond queue
 	// all the tokens are returned, so we don't need to reduce the bond anymore
-	if bondReductions := k.getSequencerDecreasingBonds(ctx, seq.Address); len(bondReductions) > 0 {
-		for _, bondReduce := range bondReductions {
-			k.removeDecreasingBondQueue(ctx, bondReduce)
+	if bondReductionIDs := k.getBondReductionIDsBySequencer(ctx, seq.Address); len(bondReductionIDs) > 0 {
+		for _, bondReductionID := range bondReductionIDs {
+			bondReduction, found := k.GetBondReduction(ctx, bondReductionID)
+			if found {
+				k.removeBondReduction(ctx, bondReductionID, bondReduction)
+			}
 		}
 	}
 

--- a/x/sequencer/keeper/unbond_test.go
+++ b/x/sequencer/keeper/unbond_test.go
@@ -143,7 +143,7 @@ func (suite *SequencerTestSuite) TestHandleBondReduction() {
 	sequencer, _ := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, defaultSequencerAddress)
 	suite.Require().Equal(bond.AddAmount(sdk.NewInt(50)), sequencer.Tokens[0])
 	// ensure the bond decresing queue is empty
-	reds := suite.App.SequencerKeeper.GetMatureDecreasingBondSequencers(suite.Ctx, expectedCompletionTime)
+	reds := suite.App.SequencerKeeper.GetMatureDecreasingBondIDs(suite.Ctx, expectedCompletionTime)
 	suite.Require().Len(reds, 0)
 }
 
@@ -175,7 +175,7 @@ func (suite *SequencerTestSuite) TestHandleBondReduction_MinBondIncrease() {
 	sequencer, _ := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, defaultSequencerAddress)
 	suite.Require().Equal(bond.AddAmount(sdk.NewInt(60)), sequencer.Tokens[0])
 	// ensure the bond decresing queue is empty
-	reds := suite.App.SequencerKeeper.GetMatureDecreasingBondSequencers(suite.Ctx, expectedCompletionTime)
+	reds := suite.App.SequencerKeeper.GetMatureDecreasingBondIDs(suite.Ctx, expectedCompletionTime)
 	suite.Require().Len(reds, 0)
 	// Ensure the bond has been refunded
 	curBalance = suite.App.BankKeeper.GetBalance(suite.Ctx, sdk.MustAccAddressFromBech32(defaultSequencerAddress), bondDenom)

--- a/x/sequencer/types/errors.go
+++ b/x/sequencer/types/errors.go
@@ -31,4 +31,5 @@ var (
 	ErrInvalidURL               = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid url")
 	ErrInvalidMetadata          = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid metadata")
 	ErrInvalidVMTypeUpdate      = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid vm type update")
+	ErrUnknownBondReduction     = errorsmod.Wrap(gerrc.ErrNotFound, "unknown bond reduction")
 )

--- a/x/sequencer/types/keys.go
+++ b/x/sequencer/types/keys.go
@@ -5,6 +5,8 @@ import (
 	fmt "fmt"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/dymensionxyz/dymension/v3/utils"
 )
 
@@ -47,9 +49,13 @@ var (
 	UnbondedSequencersKeyPrefix  = []byte{0xa2}
 	UnbondingSequencersKeyPrefix = []byte{0xa3}
 
-	UnbondingQueueKey      = []byte{0x41} // prefix for the timestamps in unbonding queue
-	NoticePeriodQueueKey   = []byte{0x42} // prefix for the timestamps in notice period queue
-	DecreasingBondQueueKey = []byte{0x43} // prefix for the timestamps in decreasing bond queue
+	UnbondingQueueKey    = []byte{0x41} // prefix for the timestamps in unbonding queue
+	NoticePeriodQueueKey = []byte{0x42} // prefix for the timestamps in notice period queue
+
+	DecreasingBondQueueKey     = []byte{0x43} // prefix for the timestamps in decreasing bond queue
+	DecreasingBondIndexKey     = []byte{0x44} // prefix for the index count for bond reductions
+	DecreasingBondSequencerKey = []byte{0x45} // prefix for the decreasing bond queue by sequencer
+	DecreasingBondIDKey        = []byte{0x46} // prefix for the decreasing bond count - used to generate ID
 )
 
 /* --------------------- specific sequencer address keys -------------------- */
@@ -123,6 +129,25 @@ func GetDecreasingBondQueueKey(sequencerAddress string, endTime time.Time) []byt
 	key := DecreasingBondQueueByTimeKey(endTime)
 	key = append(key, KeySeparator...)
 	key = append(key, []byte(sequencerAddress)...)
+	return key
+}
+
+func GetDecreasingBondIndexKey(bondReductionID uint64) []byte {
+	key := DecreasingBondIndexKey
+	key = append(key, KeySeparator...)
+	key = append(key, sdk.Uint64ToBigEndian(bondReductionID)...)
+	return key
+}
+
+func GetDecreasingBondIDKey() []byte {
+	return DecreasingBondIDKey
+}
+
+func GetDecreasingBondSequencerKey(sequencerAddress string) []byte {
+	key := DecreasingBondSequencerKey
+	key = append(key, KeySeparator...)
+	key = append(key, []byte(sequencerAddress)...)
+	key = append(key, KeySeparator...)
 	return key
 }
 


### PR DESCRIPTION
## Description

Modifying the storage of bond reductions queue to allow for more optimal queries.
The changes include to generate a unique bondReductionID for each item in the queue and store it indexed by time of bond reduction maturing as well as by sequencer address. This allows efficient lookup by sequencer address, which is performed for every new `MsgDecreaseBond` as well as in case of any slashing/jailing

----

Closes #1065

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ]  Targeted PR against the correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

----

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
