### PR TITLE
Fix typos readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ validate with:
 ```sh
 dymd q incentives active-gauges
 
-# alternatively, watch the outpup - you will see the "amount" change every minute
+# alternatively, watch the output - you will see the "amount" change every minute
 #  watch -n1 -d "dymd q incentives active-gauges --output json | jq '.data[] | { "id": .id, "coins": .coins } '"
 ```
 


### PR DESCRIPTION
## Description
> [!NOTE]  
> Corrected a typo in the "Checking rewards" section where "outpup" was replaced with "output" in the script comment for watching the incentives gauge output.
