### PR TITLE
fix(sequencers): incorrect sorting mechanism allows manipulation of proposer selection

### DIFF
--- a/x/sequencer/keeper/invariants.go
+++ b/x/sequencer/keeper/invariants.go
@@ -107,6 +107,13 @@ func SequencerPositiveBalancePostBondReduction(k Keeper) sdk.Invariant {
 		sequencers := k.GetAllSequencers(ctx)
 		for _, seq := range sequencers {
 			effectiveBond := seq.Tokens
+
+			// assert single denom for bond
+			if effectiveBond.Len() != 1 {
+				broken = true
+				msg += "sequencer has multiple denoms " + seq.Address + "\n"
+			}
+
 			if bondReductions := k.GetBondReductionsBySequencer(ctx, seq.Address); len(bondReductions) > 0 {
 				for _, bd := range bondReductions {
 					effectiveBond = effectiveBond.Sub(bd.DecreaseBondAmount)

--- a/x/sequencer/keeper/msg_server_create_sequencer_test.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer_test.go
@@ -32,12 +32,6 @@ func (suite *SequencerTestSuite) TestMinBond() {
 		expectedError error
 	}{
 		{
-			name:          "No bond required",
-			requiredBond:  sdk.Coin{},
-			bond:          sdk.NewCoin("adym", sdk.NewInt(10000000)),
-			expectedError: nil,
-		},
-		{
 			name:          "Valid bond",
 			requiredBond:  bond,
 			bond:          bond,

--- a/x/sequencer/keeper/msg_server_create_sequencer_test.go
+++ b/x/sequencer/keeper/msg_server_create_sequencer_test.go
@@ -49,45 +49,63 @@ func (suite *SequencerTestSuite) TestMinBond() {
 			bond:          sdk.NewCoin(bond.Denom, bond.Amount.Quo(sdk.NewInt(2))),
 			expectedError: types.ErrInsufficientBond,
 		},
+		{
+			name:          "wrong bond denom",
+			requiredBond:  bond,
+			bond:          sdk.NewCoin("eth", bond.Amount),
+			expectedError: types.ErrInvalidCoinDenom,
+		},
 	}
 
 	for _, tc := range testCases {
-		seqParams := types.DefaultParams()
-		seqParams.MinBond = tc.requiredBond
-		suite.App.SequencerKeeper.SetParams(suite.Ctx, seqParams)
+		suite.Run(tc.name, func() {
+			seqParams := types.DefaultParams()
+			seqParams.MinBond = tc.requiredBond
+			suite.App.SequencerKeeper.SetParams(suite.Ctx, seqParams)
 
-		rollappId, pk := suite.CreateDefaultRollapp()
+			rollappId, pk := suite.CreateDefaultRollapp()
 
-		// fund account
-		addr := sdk.AccAddress(pk.Address())
-		pkAny, err := codectypes.NewAnyWithValue(pk)
-		suite.Require().Nil(err)
-		err = bankutil.FundAccount(suite.App.BankKeeper, suite.Ctx, addr, sdk.NewCoins(tc.bond))
-		suite.Require().Nil(err)
+			// fund account
+			addr := sdk.AccAddress(pk.Address())
+			pkAny, err := codectypes.NewAnyWithValue(pk)
+			suite.Require().Nil(err)
+			err = bankutil.FundAccount(suite.App.BankKeeper, suite.Ctx, addr, sdk.NewCoins(tc.bond))
+			suite.Require().Nil(err)
 
-		sequencerMsg1 := types.MsgCreateSequencer{
-			Creator:      addr.String(),
-			DymintPubKey: pkAny,
-			Bond:         bond,
-			RollappId:    rollappId,
-			Metadata: types.SequencerMetadata{
-				Rpcs: []string{"https://rpc.wpd.evm.rollapp.noisnemyd.xyz:443"},
-			},
-		}
-		_, err = suite.msgServer.CreateSequencer(suite.Ctx, &sequencerMsg1)
-		if tc.expectedError != nil {
-			tc := tc
-			suite.Require().ErrorAs(err, &tc.expectedError, tc.name)
-		} else {
-			suite.Require().NoError(err)
-			sequencer, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr.String())
-			suite.Require().True(found, tc.name)
-			if tc.requiredBond.IsNil() {
-				suite.Require().True(sequencer.Tokens.IsZero(), tc.name)
-			} else {
-				suite.Require().Equal(sdk.NewCoins(tc.requiredBond), sequencer.Tokens, tc.name)
+			sequencerMsg1 := types.MsgCreateSequencer{
+				Creator:      addr.String(),
+				DymintPubKey: pkAny,
+				Bond:         tc.bond,
+				RollappId:    rollappId,
+				Metadata: types.SequencerMetadata{
+					Rpcs: []string{"https://rpc.wpd.evm.rollapp.noisnemyd.xyz:443"},
+				},
 			}
-		}
+
+			// Use a defer and recover to catch potential panics
+			var createErr error
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						createErr = fmt.Errorf("panic in CreateSequencer: %v", r)
+					}
+				}()
+				_, createErr = suite.msgServer.CreateSequencer(suite.Ctx, &sequencerMsg1)
+			}()
+
+			if tc.expectedError != nil {
+				suite.Require().ErrorAs(createErr, &tc.expectedError, tc.name)
+			} else {
+				suite.Require().NoError(createErr)
+				sequencer, found := suite.App.SequencerKeeper.GetSequencer(suite.Ctx, addr.String())
+				suite.Require().True(found, tc.name)
+				if tc.requiredBond.IsNil() {
+					suite.Require().True(sequencer.Tokens.IsZero(), tc.name)
+				} else {
+					suite.Require().Equal(sdk.NewCoins(tc.requiredBond), sequencer.Tokens, tc.name)
+				}
+			}
+		})
 	}
 }
 

--- a/x/sequencer/keeper/msg_server_increase_bond.go
+++ b/x/sequencer/keeper/msg_server_increase_bond.go
@@ -29,6 +29,11 @@ func (k msgServer) IncreaseBond(goCtx context.Context, msg *types.MsgIncreaseBon
 		return nil, err
 	}
 
+	// validate the addition amt is of same denom of existing bond
+	if found, _ := sequencer.Tokens.Find(msg.AddAmount.Denom); !found {
+		return nil, types.ErrInvalidCoinDenom
+	}
+
 	// update the sequencers bond amount in state
 	sequencer.Tokens = sequencer.Tokens.Add(msg.AddAmount)
 	k.UpdateSequencer(ctx, &sequencer, sequencer.Status)

--- a/x/sequencer/keeper/unbond.go
+++ b/x/sequencer/keeper/unbond.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"time"
 
 	errorsmod "cosmossdk.io/errors"
@@ -72,6 +73,9 @@ func (k Keeper) InstantUnbondAllSequencers(ctx sdk.Context, rollappID string) er
 func (k Keeper) reduceSequencerBond(ctx sdk.Context, seq *types.Sequencer, amt sdk.Coins, burn bool) error {
 	if amt.IsZero() {
 		return nil
+	}
+	if !seq.Tokens.IsAllGTE(amt) {
+		return fmt.Errorf("sequencer does not have enough bond: got %s, reducing by %s", seq.Tokens.String(), amt.String())
 	}
 	if burn {
 		err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, amt)

--- a/x/sequencer/types/msg_create_sequencer.go
+++ b/x/sequencer/types/msg_create_sequencer.go
@@ -100,7 +100,7 @@ func (msg *MsgCreateSequencer) ValidateBasic() error {
 		return errorsmod.Wrap(ErrInvalidMetadata, err.Error())
 	}
 
-	if !msg.Bond.IsValid() {
+	if !msg.Bond.IsValid() || msg.Bond.IsZero() {
 		return errorsmod.Wrapf(ErrInvalidCoins, "invalid bond amount: %s", msg.Bond.String())
 	}
 

--- a/x/sequencer/types/params.go
+++ b/x/sequencer/types/params.go
@@ -62,7 +62,7 @@ func validateMinBond(i interface{}) error {
 	}
 
 	if v.IsNil() || v.IsZero() {
-		return nil
+		return fmt.Errorf("min bond must be positive: %s", v)
 	}
 
 	if !v.IsValid() {


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

----

Closes #1291 

This PR does the following:
* better enforcement of single denom for sequencer bond 
* requires `MinBond` param to be > 0 (instead >= 0 currently)
