### PR TITLE
fix(crisis): Fix crisis module wiring

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -189,10 +189,6 @@ func (a *AppKeepers) InitKeepers(
 
 	a.CapabilityKeeper.Seal()
 
-	a.CrisisKeeper = crisiskeeper.NewKeeper(
-		appCodec, a.keys[crisistypes.StoreKey], invCheckPeriod, a.BankKeeper, authtypes.FeeCollectorName, govModuleAddress,
-	)
-
 	a.UpgradeKeeper = upgradekeeper.NewKeeper(
 		skipUpgradeHeights,
 		a.keys[upgradetypes.StoreKey],
@@ -224,6 +220,10 @@ func (a *AppKeepers) InitKeepers(
 		a.AccountKeeper,
 		moduleAccountAddrs,
 		govModuleAddress,
+	)
+
+	a.CrisisKeeper = crisiskeeper.NewKeeper(
+		appCodec, a.keys[crisistypes.StoreKey], invCheckPeriod, a.BankKeeper, authtypes.FeeCollectorName, govModuleAddress,
 	)
 
 	a.StakingKeeper = stakingkeeper.NewKeeper(

--- a/scripts/src/genesis_config_commands.sh
+++ b/scripts/src/genesis_config_commands.sh
@@ -17,7 +17,6 @@ set_hub_params() {
     jq '.app_state.rollapp.params.dispute_period_in_blocks = "50"' "$GENESIS_FILE" > "$tmp" && mv "$tmp" "$GENESIS_FILE"
     
     
-    jq '.app_state.sequencer.params.unbonding_time = "1209600s"' "$GENESIS_FILE" > "$tmp" && mv "$tmp" "$GENESIS_FILE"
     jq '.app_state.sequencer.params.notice_period = "60s"' "$GENESIS_FILE" > "$tmp" && mv "$tmp" "$GENESIS_FILE"
 
     #increase the tx size cost per byte from 10 to 100

--- a/x/delayedack/client/cli/query.go
+++ b/x/delayedack/client/cli/query.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	commontypes "github.com/dymensionxyz/dymension/v3/x/common/types"
 	"github.com/dymensionxyz/dymension/v3/x/delayedack/types"
 )
@@ -223,13 +225,18 @@ func CmdGetPendingPacketsByAddress() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pending-packets-by-address [address]",
 		Short: "Get pending packets by address",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
 			queryClient := types.NewQueryClient(clientCtx)
+
+			_, err = sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
 
 			res, err := queryClient.GetPendingPacketsByAddress(cmd.Context(), &types.QueryPendingPacketsByAddressRequest{
 				Address:    args[0],


### PR DESCRIPTION
`crisisKeeper` gets `nil` `bankKeeper`
which makes it panic when handling invariant