### PR TITLE
fix(lightclient): don't expect signer

### DIFF
--- a/x/lightclient/keeper/hook_listener.go
+++ b/x/lightclient/keeper/hook_listener.go
@@ -65,7 +65,8 @@ func (hook rollappHook) AfterUpdateState(
 	// we now verified everything up to and including stateInfo.GetLatestHeight()-1
 	// so we should prune everything up to stateInfo.GetLatestHeight()-1
 	// this removes the unbonding condition for the sequencers
-	if err := hook.k.PruneSignersBelow(ctx, client, stateInfo.GetLatestHeight()); err != nil {
+	// TODO: when integrating with hard fork PR need to change rollapp argument to client argument
+	if err := hook.k.PruneSignersBelow(ctx, rollappId, stateInfo.GetLatestHeight()); err != nil {
 		return errorsmod.Wrap(err, "prune signers")
 	}
 

--- a/x/lightclient/keeper/hook_listener.go
+++ b/x/lightclient/keeper/hook_listener.go
@@ -94,10 +94,20 @@ func (hook rollappHook) validateOptimisticUpdate(
 		BlockDescriptor:    expectBD,
 		NextBlockSequencer: nextSequencer,
 	}
+	foundSigner := true
 	signerAddr, err := hook.k.GetSigner(ctx, client, h)
 	if err != nil {
-		return gerrc.ErrInternal.Wrapf("got cons state but no signer addr: client: %s: h: %d", client, h)
+		if !errorsmod.IsOf(err, gerrc.ErrNotFound) {
+			return gerrc.ErrInternal.Wrapf("got cons state but no signer addr: client: %s: h: %d", client, h)
+		}
+		foundSigner = false
 	}
+	err = types.CheckCompatibility(*got, expect)
+	if err == nil {
+		// everything is fine
+		return nil
+	}
+
 	signer, err := hook.k.SeqK.RealSequencer(ctx, signerAddr)
 	if err != nil {
 		return gerrc.ErrInternal.Wrapf("got cons state but no signer seq: client: %s: h: %d: signer addr: %s", client, h, signerAddr)
@@ -107,11 +117,7 @@ func (hook rollappHook) validateOptimisticUpdate(
 	if err != nil {
 		return errorsmod.Wrap(err, "remove signer")
 	}
-	err = types.CheckCompatibility(*got, expect)
-	if err == nil {
-		// everything is fine
-		return nil
-	}
+
 	// fraud!
 	err = hook.k.rollappKeeper.HandleFraud(ctx, signer.RollappId, client, h, signer.Address)
 	if err != nil {

--- a/x/lightclient/keeper/hook_listener.go
+++ b/x/lightclient/keeper/hook_listener.go
@@ -44,16 +44,11 @@ func (hook rollappHook) AfterUpdateState(
 		client, ok = hook.k.GetProspectiveCanonicalClient(ctx, rollappId, stateInfo.GetLatestHeight()-1)
 		if ok {
 			hook.k.SetCanonicalClient(ctx, rollappId, client)
-			// we now verified everything up to and including stateInfo.GetLatestHeight()-1
-			// so we should prune everything up to stateInfo.GetLatestHeight()-1
-			if err := hook.k.PruneSignersBelow(ctx, rollappId, stateInfo.GetLatestHeight()); err != nil {
-				return errorsmod.Wrap(err, "prune signers")
-			}
 		}
-	}
-	if !ok {
 		return nil
 	}
+
+	// TODO: check hard fork in progress here
 
 	seq, err := hook.k.SeqK.RealSequencer(ctx, stateInfo.Sequencer)
 	if err != nil {
@@ -63,13 +58,17 @@ func (hook rollappHook) AfterUpdateState(
 	// [hStart-1..,hEnd) is correct because we compare against a next validators hash
 	for h := stateInfo.GetStartHeight() - 1; h < stateInfo.GetLatestHeight(); h++ {
 		if err := hook.validateOptimisticUpdate(ctx, rollappId, client, seq, stateInfo, h); err != nil {
-			if errorsmod.IsOf(err, gerrc.ErrFault) {
-				// TODO: should double check this flow when implementing hard fork
-				break
-			}
-			return errorsmod.Wrap(err, "validate optimistic")
+			return errorsmod.Wrap(err, "validate optimistic update")
 		}
 	}
+
+	// we now verified everything up to and including stateInfo.GetLatestHeight()-1
+	// so we should prune everything up to stateInfo.GetLatestHeight()-1
+	// this removes the unbonding condition for the sequencers
+	if err := hook.k.PruneSignersBelow(ctx, client, stateInfo.GetLatestHeight()); err != nil {
+		return errorsmod.Wrap(err, "prune signers")
+	}
+
 	return nil
 }
 
@@ -94,30 +93,14 @@ func (hook rollappHook) validateOptimisticUpdate(
 		BlockDescriptor:    expectBD,
 		NextBlockSequencer: nextSequencer,
 	}
-	signerAddr, err := hook.k.GetSigner(ctx, client, h)
-	if err != nil {
-		return gerrc.ErrInternal.Wrapf("got cons state but no signer addr: client: %s: h: %d", client, h)
-	}
-	signer, err := hook.k.SeqK.RealSequencer(ctx, signerAddr)
-	if err != nil {
-		return gerrc.ErrInternal.Wrapf("got cons state but no signer seq: client: %s: h: %d: signer addr: %s", client, h, signerAddr)
-	}
-	// remove to allow unbond
-	err = hook.k.RemoveSigner(ctx, signer.Address, client, h)
-	if err != nil {
-		return errorsmod.Wrap(err, "remove signer")
-	}
+
 	err = types.CheckCompatibility(*got, expect)
-	if err == nil {
-		// everything is fine
-		return nil
-	}
-	// fraud!
-	err = hook.k.rollappKeeper.HandleFraud(ctx, signer.RollappId, client, h, signer.Address)
 	if err != nil {
-		return errorsmod.Wrap(err, "handle fraud")
+		return errors.Join(gerrc.ErrFault, err)
 	}
-	return gerrc.ErrFault
+
+	// everything is fine
+	return nil
 }
 
 func (hook rollappHook) getBlockDescriptor(ctx sdk.Context,

--- a/x/lightclient/keeper/hook_listener_test.go
+++ b/x/lightclient/keeper/hook_listener_test.go
@@ -70,7 +70,7 @@ func TestAfterUpdateState(t *testing.T) {
 					},
 				}
 			},
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name: "state is compatible",

--- a/x/lightclient/keeper/keeper.go
+++ b/x/lightclient/keeper/keeper.go
@@ -168,6 +168,15 @@ func (k Keeper) GetSigner(ctx sdk.Context, client string, h uint64) (string, err
 	return k.clientHeightToSigner.Get(ctx, collections.Join(client, h))
 }
 
+func (k Keeper) GetSignerSeq(ctx sdk.Context, client string, h uint64) (sequencertypes.Sequencer, error) {
+	a
+	ret, err := k.clientHeightToSigner.Get(ctx, collections.Join(client, h))
+	if errorsmod.IsOf(err, collections.ErrNotFound) {
+		return "", errors.Join(err, gerrc.ErrNotFound)
+	}
+	return ret, err
+}
+
 func (k Keeper) SaveSigner(ctx sdk.Context, seqAddr string, client string, h uint64) error {
 	return errors.Join(
 		k.headerSigners.Set(ctx, collections.Join3(seqAddr, client, h)),

--- a/x/lightclient/keeper/keeper.go
+++ b/x/lightclient/keeper/keeper.go
@@ -168,15 +168,6 @@ func (k Keeper) GetSigner(ctx sdk.Context, client string, h uint64) (string, err
 	return k.clientHeightToSigner.Get(ctx, collections.Join(client, h))
 }
 
-func (k Keeper) GetSignerSeq(ctx sdk.Context, client string, h uint64) (sequencertypes.Sequencer, error) {
-	a
-	ret, err := k.clientHeightToSigner.Get(ctx, collections.Join(client, h))
-	if errorsmod.IsOf(err, collections.ErrNotFound) {
-		return "", errors.Join(err, gerrc.ErrNotFound)
-	}
-	return ret, err
-}
-
 func (k Keeper) SaveSigner(ctx sdk.Context, seqAddr string, client string, h uint64) error {
 	return errors.Join(
 		k.headerSigners.Set(ctx, collections.Join3(seqAddr, client, h)),


### PR DESCRIPTION
Solves arts testnet issue

```
Nov 11 15:09:41 ip-10-0-2-46 rollapp-evm[12691]: time="2024-11-11T15:09:41Z" level=error msg="Submit batch[startHeight 776661 endHeight 0x2aee4e0 error broadcast tx: rpc error: code = Unknown desc = rpc error: code = Unknown desc = failed to execute message; message index: 0: hook: after update state: validate optimistic: got cons state but no signer addr: client: 07-tendermint-44: h: 776660: internal [cosmossdk.io/errors@v1.0.1/errors.go:155] With gas wanted: '18446744073709551615' and gas used: '443375' : unknown request]" module=settlement_client

```


We shouldn't expect light client signers for consensus states from pre upgrade rollapps.

This PR just makes the file the same as it is in https://github.com/dymensionxyz/dymension/pull/1354, which also fixes the problem because there is no automatic forking there, and the signer isn't looked up