### PR TITLE
fix(sponsorship): removed redundant ceiling while calculating staking power

### DIFF
--- a/x/sponsorship/keeper/hooks.go
+++ b/x/sponsorship/keeper/hooks.go
@@ -63,7 +63,7 @@ func (h Hooks) afterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, 
 	}
 
 	// Calculate a staking voting power
-	stakingVP := v.TokensFromShares(d.GetShares()).Ceil().TruncateInt()
+	stakingVP := v.TokensFromShares(d.GetShares()).TruncateInt()
 
 	// Get the current voting power saved in x/sponsorship. If the VP is not found, then we yet don't
 	// have a relevant record. This is a valid case when the VP is zero.
@@ -189,7 +189,7 @@ func (h Hooks) processHook(
 			distribution: distr,
 			votePruned:   true,
 			vpDiff:       powerDiff,
-			newTotal:     vote.VotingPower,
+			newTotal:     newTotalVP,
 		}, nil
 	}
 

--- a/x/sponsorship/keeper/keeper_test.go
+++ b/x/sponsorship/keeper/keeper_test.go
@@ -116,7 +116,7 @@ func (s *KeeperTestSuite) Vote(vote types.MsgVote) {
 func (s *KeeperTestSuite) CreateValidator() stakingtypes.ValidatorI {
 	s.T().Helper()
 
-	valAddrs := apptesting.AddTestAddrs(s.App, s.Ctx, 1, sdk.NewInt(1_000_000_000))
+	valAddrs := apptesting.AddTestAddrs(s.App, s.Ctx, 1, types.DYM.MulRaw(1_000))
 
 	// Build MsgCreateValidator
 	valAddr := sdk.ValAddress(valAddrs[0].Bytes())
@@ -178,7 +178,7 @@ func (s *KeeperTestSuite) CreateValidatorWithAddress(acc sdk.AccAddress, balance
 func (s *KeeperTestSuite) CreateDelegator(valAddr sdk.ValAddress, coin sdk.Coin) stakingtypes.DelegationI {
 	s.T().Helper()
 
-	delAddrs := apptesting.AddTestAddrs(s.App, s.Ctx, 1, sdk.NewInt(1_000_000_000))
+	delAddrs := apptesting.AddTestAddrs(s.App, s.Ctx, 1, types.DYM.MulRaw(1_000))
 	delAddr := delAddrs[0]
 	return s.Delegate(delAddr, valAddr, coin)
 }

--- a/x/sponsorship/keeper/msg_server.go
+++ b/x/sponsorship/keeper/msg_server.go
@@ -31,18 +31,9 @@ func (m MsgServer) Vote(goCtx context.Context, msg *types.MsgVote) (*types.MsgVo
 	// Don't check the error since it's part of validation
 	voter := sdk.MustAccAddressFromBech32(msg.Voter)
 
-	vote, distr, err := m.k.Vote(ctx, voter, msg.Weights)
+	_, _, err = m.k.Vote(ctx, voter, msg.Weights)
 	if err != nil {
 		return nil, err
-	}
-
-	err = uevent.EmitTypedEvent(ctx, &types.EventVote{
-		Voter:        msg.Voter,
-		Vote:         vote,
-		Distribution: distr,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("emit event: %w", err)
 	}
 
 	return &types.MsgVoteResponse{}, nil
@@ -58,17 +49,9 @@ func (m MsgServer) RevokeVote(goCtx context.Context, msg *types.MsgRevokeVote) (
 	// Don't check the error since it's part of validation
 	voter := sdk.MustAccAddressFromBech32(msg.Voter)
 
-	distr, err := m.k.RevokeVote(ctx, voter)
+	_, err = m.k.RevokeVote(ctx, voter)
 	if err != nil {
 		return nil, err
-	}
-
-	err = uevent.EmitTypedEvent(ctx, &types.EventRevokeVote{
-		Voter:        msg.Voter,
-		Distribution: distr,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("emit event: %w", err)
 	}
 
 	return &types.MsgRevokeVoteResponse{}, nil


### PR DESCRIPTION
… power

## Description

- Removed redundant ceiling while calculating staking power
- Reordered events, so now they are more transparent
- Fixed incorrect field in `EventVotingPowerUpdate` when the vote is removed

----

Closes #XXX

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ]  Targeted PR against the correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

----

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
