### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/x/iro/types/genesis.pb.go
+++ b/x/iro/types/genesis.pb.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/cosmos/cosmos-proto"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	proto "github.com/cosmos/gogoproto/proto"
+	"errors"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -210,7 +211,7 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: GenesisState: wiretype end group for non-group")
+			return errors.New("proto: GenesisState: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: GenesisState: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -384,7 +385,7 @@ func skipGenesis(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthGenesis        = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowGenesis          = fmt.Errorf("proto: integer overflow")
-	ErrUnexpectedEndOfGroupGenesis = fmt.Errorf("proto: unexpected end of group")
+	ErrInvalidLengthGenesis        = errors.New("proto: negative length found during unmarshaling")
+	ErrIntOverflowGenesis          = errors.New("proto: integer overflow")
+	ErrUnexpectedEndOfGroupGenesis = errors.New("proto: unexpected end of group")
 )


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters