### PR TITLE
Fix minor typos

### DIFF
--- a/app/genesis.go
+++ b/app/genesis.go
@@ -9,7 +9,7 @@ import (
 )
 
 // The genesis state of the blockchain is represented here as a map of raw json
-// messages key'd by a identifier string.
+// messages key'd by an identifier string.
 // The identifier is used to determine which module genesis information belongs
 // to so it may be appropriately routed during init chain.
 // Within this application default genesis information is retrieved from

--- a/x/common/types/packet_uid.go
+++ b/x/common/types/packet_uid.go
@@ -2,7 +2,7 @@ package types
 
 import "fmt"
 
-// PacketUID is a unique identifier for an Rollapp IBC packet on the hub
+// PacketUID is a unique identifier for a Rollapp IBC packet on the hub
 type PacketUID struct {
 	Type              RollappPacket_Type
 	RollappHubPort    string

--- a/x/lightclient/types/params.go
+++ b/x/lightclient/types/params.go
@@ -25,7 +25,7 @@ const (
 	trustPeriodMultiplier = 65
 )
 
-// expectedTrustPeriod calculates an sensible trust period based on unbonding period
+// expectedTrustPeriod calculates a sensible trust period based on unbonding period
 // taking into account potential high skew between L1 and L2
 // See https://github.com/dymensionxyz/dymension/issues/1209
 func expectedTrustPeriod(unbondingPeriod time.Duration) time.Duration {

--- a/x/lockup/keeper/msg_server.go
+++ b/x/lockup/keeper/msg_server.go
@@ -202,7 +202,7 @@ func (server msgServer) ForceUnlock(goCtx context.Context, msg *types.MsgForceUn
 	forceUnlockAllowedAddresses := server.keeper.GetParams(ctx).ForceUnlockAllowedAddresses
 	found := false
 	for _, addr := range forceUnlockAllowedAddresses {
-		// defense in depth, double checking the message owner and lock owner are both the same and is one of the allowed force unlock addresses
+		// defense in depth, double-checking the message owner and lock owner are both the same and is one of the allowed force unlock addresses
 		if addr == lock.Owner && addr == msg.Owner {
 			found = true
 			break

--- a/x/rollapp/keeper/sequencer_hooks.go
+++ b/x/rollapp/keeper/sequencer_hooks.go
@@ -12,7 +12,7 @@ type SequencerHooks struct {
 	*Keeper
 }
 
-// AfterRecoveryFromHalt is called after a new sequencer is set the proposer for an halted rollapp.
+// AfterRecoveryFromHalt is called after a new sequencer is set the proposer for a halted rollapp.
 // We assume the rollapp had forked once halted
 func (h SequencerHooks) AfterSetRealProposer(ctx sdk.Context, rollapp string, newSeq sequencertypes.Sequencer) error {
 	// Start the liveness clock from zero


### PR DESCRIPTION
This PR corrects minor typos in comments across various files to enhance clarity and maintain consistency in the codebase documentation.

---

### Files Updated  
1. **app/genesis.go**  
   - Fixed "key'd by a identifier string" to "key'd by an identifier string."

2. **x/common/types/packet_uid.go**  
   - Corrected "an Rollapp IBC packet" to "a Rollapp IBC packet."

3. **x/lightclient/types/params.go**  
   - Updated "calculates an sensible trust period" to "calculates a sensible trust period."

4. **x/lockup/keeper/msg_server.go**  
   - Improved clarity by changing "defense in depth, double checking" to "defense in depth, double-checking."

5. **x/rollapp/keeper/sequencer_hooks.go**  
   - Fixed "proposer for an halted rollapp" to "proposer for a halted rollapp."
