### PR TITLE
Fix spelling

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -63,7 +63,7 @@ ErrFoo = errors.New("foo")
 return errorsmod.Wrap(ErrFoo, "bar")
 ```
 
-7. Use the Dymension cosmos error library as basis for errors. They are automatically converted to GRPC codes and registered. Choose the appropriate pre defined `gerrc.Err*`, considering API. This is based on the following principle from Google API guidelines
+7. Use the Dymension cosmos error library as basis for errors. They are automatically converted to GRPC codes and registered. Choose the appropriate pre-defined `gerrc.Err*`, considering API. This is based on the following principle from Google API guidelines
 
 >(Google) APIs must use the canonical error codes defined by google.rpc.Code. Individual APIs must avoid defining additional error codes, since developers are very unlikely to write logic to handle a large number of error codes. For reference, handling an average of three error codes per API call would mean most application logic would just be for error handling, which would not be a good developer experience.
 

--- a/x/incentives/README.md
+++ b/x/incentives/README.md
@@ -11,7 +11,7 @@ Anyone can create gauge and add rewards to the gauge, there is no way to take it
 There are two kinds of `gauges`, perpetual and non-perpetual ones.
 
 - Non-perpetual ones get removed from active queue after the distribution period finish but perpetual ones persist.
-- For non perpetual ones, they distribute the tokens equally per epoch during the `gauge` is in the active period.
+- For non-perpetual ones, they distribute the tokens equally per epoch during the `gauge` is in the active period.
 - For perpetual ones, it distributes all the tokens at a single time. Those gauges need to be filled externally.
 
 ## Contents

--- a/x/incentives/README.md
+++ b/x/incentives/README.md
@@ -10,7 +10,7 @@ Anyone can create gauge and add rewards to the gauge, there is no way to take it
 
 There are two kinds of `gauges`, perpetual and non-perpetual ones.
 
-- Non perpetual ones get removed from active queue after the distribution period finish but perpetual ones persist.
+- Non-perpetual ones get removed from active queue after the distribution period finish but perpetual ones persist.
 - For non perpetual ones, they distribute the tokens equally per epoch during the `gauge` is in the active period.
 - For perpetual ones, it distributes all the tokens at a single time. Those gauges need to be filled externally.
 


### PR DESCRIPTION
- Corrected "pre defined" → "pre-defined" in `Contributing.md`.
- Fixed "non perpetual" → "non-perpetual" and other related changes in `README.md`.
