### PR TITLE
fix(iro): first sell tokens, than charge fee

### DIFF
--- a/x/iro/types/bonding_curve.go
+++ b/x/iro/types/bonding_curve.go
@@ -164,13 +164,13 @@ func (lbc BondingCurve) TokensApproximation(startingX, spendTokens math.LegacyDe
 	// Newton-Raphson iteration
 	epsilonDec := math.LegacyNewDecWithPrec(1, epsilonPrecision)
 	for i := 0; i < maxIterations; i++ {
-		fx := f(x)
+		fx := f(x) // diff between spendTokens and the actual cost to get to x
 		// If the function converges, return the result
 		if fx.Abs().LT(epsilonDec) {
 			return x, i, nil
 		}
 		prevX := x
-		fPrimex := fPrime(x)
+		fPrimex := fPrime(x) // price for new X
 
 		// defensive check to avoid division by zero
 		// not supposed to happen, as spotPriceInternal should never return 0


### PR DESCRIPTION
currently, when selling IRO tokens, the user is first charged with the taker fee, and than sell it's tokens.

It can cause to failures in case the user doesn't have enough funds to pay the fee.


This PR fixes it, so the taker fee charged **AFTER** the sell outcome