### PR TITLE
typo fix msg_server.go

### DIFF
--- a/x/dymns/keeper/msg_server.go
+++ b/x/dymns/keeper/msg_server.go
@@ -27,7 +27,7 @@ func consumeMinimumGas(ctx sdk.Context, minimumGas, originalConsumedGas uint64, 
 	if minimumGas > 0 {
 		laterConsumedGas := ctx.GasMeter().GasConsumed()
 		if laterConsumedGas < originalConsumedGas {
-			// unexpect gas consumption
+			// unexpected gas consumption
 			panic(fmt.Sprintf(
 				"later gas is less than original gas: %d < %d",
 				laterConsumedGas, originalConsumedGas,


### PR DESCRIPTION
# **Fix Typo in `msg_server.go`**

## **Description**
This pull request fixes a minor typo in the comment within the `msg_server.go` file. The word **"unexpect"** was corrected to **"unexpected"** to improve clarity and maintain code readability.

## **Changes**
- Corrected typo in the following line:
  - **Before:** `// unexpect gas consumption`
  - **After:** `// unexpected gas consumption`
