### PR TITLE
feat(IRO): setting equilibrium point where the raised dym goes to the liquidity pool

### DIFF
--- a/proto/dymensionxyz/dymension/iro/iro.proto
+++ b/proto/dymensionxyz/dymension/iro/iro.proto
@@ -110,6 +110,15 @@ message Plan {
   // settled.
   IncentivePlanParams incentive_plan_params = 11
       [ (gogoproto.nullable) = false ];
+
+
+  // The maximum amount of tokens that can be sold for the plan.
+  // This ensures we'll have enough tokens to bootstrap liquidity
+  string max_amount_to_sell = 12 [
+    (cosmos_proto.scalar) = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false
+  ];
 }
 
 message IncentivePlanParams {

--- a/x/iro/cli/cli_test.go
+++ b/x/iro/cli/cli_test.go
@@ -117,7 +117,7 @@ func TestParseBondingCurve(t *testing.T) {
 		wantErr  bool
 	}{
 		{"Valid curve", "1.2,0.4,0", false},
-		{"Valid curve Ints", "2,1,1", false},
+		{"Valid curve Ints", "2,1,0", false},
 		{"Invalid params count", "1.2,0.4", true},
 		{"Invalid params count - too much", "1.2,0.4,0.1,0.2", true},
 		{"Invalid M", "invalid,0.4,0", true},

--- a/x/iro/keeper/claim_test.go
+++ b/x/iro/keeper/claim_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/dymensionxyz/dymension/v3/x/iro/types"
 )
 
+// TestClaim tests that Claim works correctly.
+//
+// It creates a rollapp, then buys some tokens on it. It then tests that Claim fails
+// if the plan is not settled. After settling the plan, it tests that Claim works
+// and that the user gets the correct amount of tokens.
 func (s *KeeperTestSuite) TestClaim() {
 	rollappId := s.CreateDefaultRollapp()
 	k := s.App.IROKeeper

--- a/x/iro/keeper/create_plan_test.go
+++ b/x/iro/keeper/create_plan_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/dymensionxyz/dymension/v3/x/iro/types"
 )
 
+// TestValidateRollappPreconditions tests the validation of rollapp preconditions in the CreatePlan function.
+// It covers the following cases:
+// - Rollapp is missing genesis checksum
+// - Rollapp is already launched
+// - Happy path with valid rollapp
 func (s *KeeperTestSuite) TestValidateRollappPreconditions() {
 	curve := types.DefaultBondingCurve()
 	incentives := types.DefaultIncentivePlanParams()
@@ -56,6 +61,14 @@ func (s *KeeperTestSuite) TestValidateRollappPreconditions() {
 	})
 }
 
+// TestCreatePlan tests the CreatePlan method of the keeper.
+// It creates a plan for a given rollapp, tests that creating a plan for the same rollapp fails,
+// creates a plan for a different rollapp and tests that the plan IDs increase.
+//
+// It also tests that the plan exists, that the plan can be retrieved by ID, and that the
+// module account has the expected creation fee.
+//
+// Finally, it tests that the genesis info is sealed after creating a plan.
 func (s *KeeperTestSuite) TestCreatePlan() {
 	rollappId := s.CreateDefaultRollapp()
 	rollappId2 := s.CreateDefaultRollapp()
@@ -106,6 +119,11 @@ func (s *KeeperTestSuite) TestCreatePlan() {
 	s.Require().True(rollapp.GenesisInfo.Sealed)
 }
 
+// TestMintAllocation tests that MintAllocation works correctly.
+//
+// It creates a rollapp and then uses MintAllocation to mint a certain amount of
+// tokens. It then asserts that the denom metadata is registered, the virtual
+// frontier bank contract is created and the coins have been minted.
 func (s *KeeperTestSuite) TestMintAllocation() {
 	rollappId := s.CreateDefaultRollapp()
 

--- a/x/iro/keeper/settle_test.go
+++ b/x/iro/keeper/settle_test.go
@@ -90,22 +90,22 @@ func (s *KeeperTestSuite) TestBootstrapLiquidityPool() {
 			expectedTokens: math.NewInt(1_001).MulRaw(1e18),
 		},
 		{
-			name:           "Large purchase - left tokens are limiting factor",
-			buyAmt:         math.NewInt(800_000).MulRaw(1e18),
-			expectedDYM:    math.NewInt(20_000).MulRaw(1e18),
-			expectedTokens: math.NewInt(200_000).MulRaw(1e18),
-		},
-		{
 			name:           "Nothing sold - pool contains only creation fee",
 			buyAmt:         math.NewInt(0),
 			expectedDYM:    math.NewInt(1).MulRaw(1e17), // creation fee
 			expectedTokens: math.NewInt(1).MulRaw(1e18),
 		},
 		{
-			name:           "All sold - pool contains only reserved tokens",
-			buyAmt:         math.NewInt(999_999).MulRaw(1e18),
-			expectedDYM:    math.NewInt(1).MulRaw(1e17), // 0.1 DYM
-			expectedTokens: math.NewInt(1).MulRaw(1e18), // reserved tokens
+			name:           "Large purchase",
+			buyAmt:         math.NewInt(399_999).MulRaw(1e18),
+			expectedDYM:    math.NewInt(40_000).MulRaw(1e18),
+			expectedTokens: math.NewInt(400_000).MulRaw(1e18),
+		},
+		{
+			name:           "All available tokens",
+			buyAmt:         maxToSell.SubRaw(1e18), // 500_000 - 1
+			expectedDYM:    math.NewInt(50_000).MulRaw(1e18),
+			expectedTokens: math.NewInt(500_000).MulRaw(1e18),
 		},
 	}
 

--- a/x/iro/keeper/settle_test.go
+++ b/x/iro/keeper/settle_test.go
@@ -30,7 +30,7 @@ func (s *KeeperTestSuite) TestSettle() {
 	s.Require().NoError(err)
 	planDenom := k.MustGetPlan(s.Ctx, planId).TotalAllocation.Denom
 
-	// assert initial FUT balance
+	// assert initial IRO balance
 	balance := s.App.BankKeeper.GetBalance(s.Ctx, k.AK.GetModuleAddress(types.ModuleName), planDenom)
 	s.Require().Equal(amt, balance.Amount)
 
@@ -43,7 +43,7 @@ func (s *KeeperTestSuite) TestSettle() {
 	err = k.Settle(s.Ctx, rollappId, rollappDenom)
 	s.Require().Error(err)
 
-	// should succeed after fund
+	// should succeed after fund (mocks the genesis bridge transfer)
 	s.FundModuleAcc(types.ModuleName, sdk.NewCoins(sdk.NewCoin(rollappDenom, amt)))
 	err = k.Settle(s.Ctx, rollappId, rollappDenom)
 	s.Require().NoError(err)
@@ -52,7 +52,7 @@ func (s *KeeperTestSuite) TestSettle() {
 	err = k.Settle(s.Ctx, rollappId, rollappDenom)
 	s.Require().Error(err)
 
-	// assert no FUT balance in the account
+	// assert no IRO balance in the account
 	balance = s.App.BankKeeper.GetBalance(s.Ctx, k.AK.GetModuleAddress(types.ModuleName), planDenom)
 	s.Require().True(balance.IsZero())
 
@@ -71,6 +71,7 @@ func (s *KeeperTestSuite) TestBootstrapLiquidityPool() {
 	startTime := time.Now()
 	allocation := math.NewInt(1_000_000).MulRaw(1e18)
 	rollappDenom := "dasdasdasdasdsa"
+	maxToSell := types.FindEquilibrium(curve, allocation)
 
 	testCases := []struct {
 		name           string

--- a/x/iro/keeper/trade.go
+++ b/x/iro/keeper/trade.go
@@ -65,7 +65,7 @@ func (k Keeper) Buy(ctx sdk.Context, planId string, buyer sdk.AccAddress, amount
 	}
 
 	// validate the IRO have enough tokens to sell
-	if plan.SoldAmt.Add(amountTokensToBuy).GT(plan.TotalAllocation.Amount) {
+	if plan.SoldAmt.Add(amountTokensToBuy).GT(plan.MaxAmountToSell) {
 		return types.ErrInsufficientTokens
 	}
 
@@ -149,7 +149,7 @@ func (k Keeper) BuyExactSpend(ctx sdk.Context, planId string, buyer sdk.AccAddre
 	}
 
 	// validate the IRO have enough tokens to sell
-	if plan.SoldAmt.Add(tokensOutAmt).GT(plan.TotalAllocation.Amount) {
+	if plan.SoldAmt.Add(tokensOutAmt).GT(plan.MaxAmountToSell) {
 		return types.ErrInsufficientTokens
 	}
 

--- a/x/iro/types/bonding_curve.go
+++ b/x/iro/types/bonding_curve.go
@@ -79,6 +79,11 @@ func (lbc BondingCurve) ValidateBasic() error {
 		return errorsmod.Wrapf(ErrInvalidBondingCurve, "c: %s", lbc.C.String())
 	}
 
+	// positive C is supported only for fixed price for now (due to equilibrium calculation)
+	if !lbc.C.IsZero() && !lbc.M.IsZero() {
+		return errorsmod.Wrapf(ErrInvalidBondingCurve, "m: %s, c: %s", lbc.M.String(), lbc.C.String())
+	}
+
 	if !checkPrecision(lbc.N) {
 		return errorsmod.Wrapf(ErrInvalidBondingCurve, "N must have at most %d decimal places", MaxNPrecision)
 	}

--- a/x/iro/types/iro.pb.go
+++ b/x/iro/types/iro.pb.go
@@ -170,6 +170,9 @@ type Plan struct {
 	// The incentive plan parameters for the tokens left after the plan is
 	// settled.
 	IncentivePlanParams IncentivePlanParams `protobuf:"bytes,11,opt,name=incentive_plan_params,json=incentivePlanParams,proto3" json:"incentive_plan_params"`
+	// The maximum amount of tokens that can be sold for the plan.
+	// This ensures we'll have enough tokens to bootstrap liquidity
+	MaxAmountToSell cosmossdk_io_math.Int `protobuf:"bytes,12,opt,name=max_amount_to_sell,json=maxAmountToSell,proto3,customtype=cosmossdk.io/math.Int" json:"max_amount_to_sell"`
 }
 
 func (m *Plan) Reset()         { *m = Plan{} }
@@ -529,6 +532,16 @@ func (m *Plan) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	var l int
 	_ = l
 	{
+		size := m.MaxAmountToSell.Size()
+		i -= size
+		if _, err := m.MaxAmountToSell.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintIro(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x62
+	{
 		size, err := m.IncentivePlanParams.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
 			return 0, err
@@ -739,6 +752,8 @@ func (m *Plan) Size() (n int) {
 	l = m.ClaimedAmt.Size()
 	n += 1 + l + sovIro(uint64(l))
 	l = m.IncentivePlanParams.Size()
+	n += 1 + l + sovIro(uint64(l))
+	l = m.MaxAmountToSell.Size()
 	n += 1 + l + sovIro(uint64(l))
 	return n
 }
@@ -1492,6 +1507,40 @@ func (m *Plan) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.IncentivePlanParams.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxAmountToSell", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowIro
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthIro
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthIro
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.MaxAmountToSell.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/iro/types/liquidity.go
+++ b/x/iro/types/liquidity.go
@@ -1,0 +1,52 @@
+package types
+
+import "cosmossdk.io/math"
+
+// CalcLiquidityPoolTokens determines the tokens and DYM to be used for bootstrapping the liquidity pool.
+//
+// This function calculates the required DYM based on the settled token price and compares it with the raised DYM.
+// It returns the amount of RA tokens and DYM to be used for bootstrapping the liquidity pool so it fulfills the last price.
+// We expect all the raised dym to be used for liquidity pool, so incentives will consist of the remaining tokens.s
+func CalcLiquidityPoolTokens(unsoldRATokens, raisedDYM math.Int, settledTokenPrice math.LegacyDec) (RATokens, dym math.Int) {
+	requiredDYM := settledTokenPrice.MulInt(unsoldRATokens).TruncateInt()
+
+	// if raisedDYM is less than requiredDYM, than DYM is the limiting factor
+	// we use all the raisedDYM, and the corresponding amount of tokens
+	if raisedDYM.LT(requiredDYM) {
+		dym = raisedDYM
+		RATokens = raisedDYM.ToLegacyDec().Quo(settledTokenPrice).TruncateInt()
+	} else {
+		// if raisedDYM is more than requiredDYM, than tokens are the limiting factor
+		// we use all the unsold tokens, and the corresponding amount of DYM
+		RATokens = unsoldRATokens
+		dym = requiredDYM
+	}
+
+	// for the edge cases where required liquidity truncated to 0
+	// we use what we have as it guaranteed to be more than 0
+	if dym.IsZero() {
+		dym = raisedDYM
+	}
+	if RATokens.IsZero() {
+		RATokens = unsoldRATokens
+	}
+
+	return
+}
+
+// find equilibrium amount that will satisfy:
+// curve price (x) = balancer pool price (y/x)
+// for p(x) = mx^N
+// eq = ((N+1) / (N+2)) * T
+func FindEquilibrium(curve BondingCurve, totalAllocation math.Int) math.Int {
+	n := curve.N
+	if curve.M.IsZero() {
+		n = math.LegacyZeroDec()
+	}
+
+	n1 := n.Add(math.LegacyOneDec())                       // N + 1
+	n2 := n1.Add(math.LegacyOneDec())                      // N + 2
+	eq := n1.Quo(n2).MulInt(totalAllocation).TruncateInt() // ((N+1) / (N+2)) * T
+
+	return eq
+}

--- a/x/iro/types/liquidity_test.go
+++ b/x/iro/types/liquidity_test.go
@@ -1,0 +1,117 @@
+package types_test
+
+import (
+	"fmt"
+	math "math"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/dymensionxyz/dymension/v3/x/iro/types"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// LogarithmicRange generates a random number in a logarithmic scale between min and max
+func LogarithmicRange(t *rapid.T, min, max int64) int64 {
+	if min <= 0 || max <= 0 || min >= max {
+		panic("min and max must be positive and min must be less than max")
+	}
+
+	// Draw a random float in the range [0, 1]
+	randomFloat := rapid.Float64Range(0, 1).Draw(t, "logRandom")
+
+	// Apply logarithmic transformation
+	logMin := math.Log(float64(min))
+	logMax := math.Log(float64(max))
+
+	// Scale the random float to the logarithmic range
+	logValue := logMin + randomFloat*(logMax-logMin)
+
+	return int64(math.Exp(logValue))
+}
+
+func TestFindEquilibrium(t *testing.T) {
+	// Define different curve types
+	testcases := []struct {
+		name string
+		n    sdkmath.LegacyDec
+	}{
+		{"Square Root", sdkmath.LegacyMustNewDecFromStr("0.5")},
+		{"Linear", sdkmath.LegacyOneDec()},
+		{"Quadratic", sdkmath.LegacyMustNewDecFromStr("1.5")},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			rapid.Check(t, func(t *rapid.T) {
+				allocation := LogarithmicRange(t, 1e3, 1e10) // 1K to 10B RA tokens allocation
+				raiseTarget := LogarithmicRange(t, 1e3, 1e6) // 1K to 1M DYM
+
+				calcaulateM := types.CalculateM(sdkmath.LegacyNewDec(raiseTarget), sdkmath.LegacyNewDec(allocation), tc.n, sdkmath.LegacyZeroDec())
+
+				curve := types.NewBondingCurve(calcaulateM, tc.n, sdkmath.LegacyZeroDec())
+				allocationScaled := sdkmath.NewInt(allocation).MulRaw(1e18)
+
+				// assert eq is > 0
+				eq := types.FindEquilibrium(curve, allocationScaled)
+				require.True(t, eq.IsPositive())
+				// assert price at eq is the same as expected pool price
+				curvePrice := curve.SpotPrice(eq)
+				actualRaised := curve.Cost(sdkmath.ZeroInt(), eq)
+				leftoverTokens := allocationScaled.Sub(eq)
+				poolPrice := actualRaised.ToLegacyDec().QuoInt(leftoverTokens)
+
+				err := approxEqual(curvePrice, poolPrice, defaultToleranceDec)
+				require.NoError(t, err)
+
+				// assert total value is same as expected
+				// totalValue := actualRaised.MulRaw(2)
+				// require.Equal(t, totalValue.String(), sdkmath.NewInt(raiseTarget).MulRaw(1e18).String())
+				// err = approxEqual(totalValue, sdkmath.NewInt(raiseTarget).MulRaw(1e18), defaultTolerance)
+				// require.NoError(t, err)
+			})
+		})
+	}
+}
+
+var (
+	defaultToleranceInt = sdkmath.NewIntWithDecimal(1, 12)    // one millionth of a dym
+	defaultToleranceDec = sdkmath.LegacyNewDecWithPrec(1, 12) // one millionth of a dym
+)
+
+// approxEqual checks if two values of different types are approximately equal
+func approxEqual(expected, actual, tolerance interface{}) error {
+	switch e := expected.(type) {
+	case sdkmath.LegacyDec:
+		a, ok := actual.(sdkmath.LegacyDec)
+		if !ok {
+			return fmt.Errorf("actual is not a sdkmath.LegacyDec")
+		}
+		tol, ok := tolerance.(sdkmath.LegacyDec)
+		if !ok {
+			return fmt.Errorf("tolerance is not a sdkmath.LegacyDec")
+		}
+
+		diff := e.Sub(a).Abs()
+		if diff.GTE(tol) {
+			return fmt.Errorf("expected %s, got %s, diff %s", e, a, diff)
+		}
+
+	case sdkmath.Int:
+		a, ok := actual.(sdkmath.Int)
+		if !ok {
+			return fmt.Errorf("actual is not a sdkmath.Int")
+		}
+		tol, ok := tolerance.(sdkmath.Int)
+		if !ok {
+			return fmt.Errorf("tolerance is not a sdkmath.Int")
+		}
+		diff := e.Sub(a).Abs()
+		if diff.GTE(tol) {
+			return fmt.Errorf("expected %s, got %s, diff %s", e, a, diff)
+		}
+	default:
+		return fmt.Errorf("unsupported type: %T", expected)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR changes the way IRO allocated tokens are handled.
In case of IRO allocation `T`,
instead of all tokens available for sell,

we find an `equilibrium` point `X`, where:
* The raised DYM for X and the unsold tokens (T-X) will have the same price as the bonding curve


It means that IRO plan will have a `max_amount_to_sell` parameter

