### PR TITLE
Fix error logging format in fraud proposal handler

### DIFF
--- a/x/lockup/README.md
+++ b/x/lockup/README.md
@@ -12,7 +12,7 @@ This module provides interfaces for other modules to iterate the locks efficient
 
 ## Contents
 
-1. **[Concept](#concepts)**
+1. **[Concepts](#concepts)**
 2. **[State](#state)**
 3. **[Messages](#messages)**
 4. **[Events](#events)**

--- a/x/rollapp/keeper/fraud_proposal.go
+++ b/x/rollapp/keeper/fraud_proposal.go
@@ -19,27 +19,27 @@ func (k Keeper) SubmitRollappFraud(goCtx context.Context, msg *types.MsgRollappF
 
 	if msg.Authority != k.authority {
 		err := errorsmod.Wrap(gerrc.ErrUnauthenticated, "only the gov module can submit fraud proposals")
-		ctx.Logger().Error("Fraud proposal.", err)
+		ctx.Logger().Error("Fraud proposal", "error", err)
 		return nil, err
 	}
 
 	if err := msg.ValidateBasic(); err != nil {
 		err = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid msg")
-		ctx.Logger().Error("Fraud proposal.", err)
+		ctx.Logger().Error("Fraud proposal", "error", err)
 		return nil, err
 	}
 
 	rollapp, found := k.GetRollapp(ctx, msg.RollappId)
 	if !found {
 		err := errorsmod.Wrap(gerrc.ErrNotFound, "rollapp not found")
-		ctx.Logger().Error("Fraud proposal.", err)
+		ctx.Logger().Error("Fraud proposal", "error", err)
 		return nil, err
 	}
 
 	// check correct revision number (to avoid sending duplicated proposals)
 	if rollapp.GetRevisionForHeight(msg.FraudHeight).Number != msg.FraudRevision {
 		err := errorsmod.Wrapf(gerrc.ErrFailedPrecondition, "fraud revision number mismatch: %d != %d", rollapp.GetRevisionForHeight(msg.FraudHeight).Number, msg.FraudRevision)
-		ctx.Logger().Error("Fraud proposal.", err)
+		ctx.Logger().Error("Fraud proposal", "error", err)
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (k Keeper) SubmitRollappFraud(goCtx context.Context, msg *types.MsgRollappF
 		err := k.SequencerK.PunishSequencer(ctx, msg.PunishSequencerAddress, msg.MustRewardee())
 		if err != nil {
 			err = errorsmod.Wrap(err, "jail sequencer")
-			ctx.Logger().Error("Fraud proposal.", err)
+			ctx.Logger().Error("Fraud proposal", "error", err)
 			return nil, err
 		}
 	}
@@ -60,7 +60,7 @@ func (k Keeper) SubmitRollappFraud(goCtx context.Context, msg *types.MsgRollappF
 	err := k.HardFork(ctx, msg.RollappId, msg.FraudHeight-1)
 	if err != nil {
 		err = errorsmod.Wrap(err, "hard fork")
-		ctx.Logger().Error("Fraud proposal.", err)
+		ctx.Logger().Error("Fraud proposal", "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
1. Fixed error logging format in `x/rollapp/keeper/fraud_proposal.go` by replacing:
ctx.Logger().Error("Fraud proposal.", err)  -->  ctx.Logger().Error("Fraud proposal", "error", err)

2. Minor fix was made in the **README.md** of the `lockup` module to correct an incorrect reference to the "Concepts" section
