### PR TITLE
refactor: replace golang.org/x/exp/slices with stdlib

### DIFF
--- a/app/apptesting/events.go
+++ b/app/apptesting/events.go
@@ -2,7 +2,7 @@ package apptesting
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // AssertEventEmitted asserts that ctx's event manager has emitted the given number of events


### PR DESCRIPTION
## Description
These experimental packages are now available in the Go standard library since Go 1.21 and Go 1.23:

`golang.org/x/exp/slices` ->slices [(https://go.dev/doc/go1.21#slices)](https://go.dev/doc/go1.21#slices)
