### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
           go-version: "1.22"

--- a/.github/workflows/label-internal-pr.yml
+++ b/.github/workflows/label-internal-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Pull Request Author and Check Membership
         id: pr

--- a/.github/workflows/release_docker_images.yml
+++ b/.github/workflows/release_docker_images.yml
@@ -25,7 +25,7 @@ jobs:
       steps:
         - 
           name: Check out the repo
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         -
           name: Set up QEMU
           uses: docker/setup-qemu-action@v3

--- a/.github/workflows/update_docker_images.yml
+++ b/.github/workflows/update_docker_images.yml
@@ -19,7 +19,7 @@ jobs:
       steps:
         - 
           name: Check out the repo
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         -
           name: Set up QEMU
           uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected