### PR TITLE
fix(sponsorship): missing total power in the endorsement migration

### DIFF
--- a/app/upgrades/v5/upgrade.go
+++ b/app/upgrades/v5/upgrade.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"cosmossdk.io/math"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -56,7 +57,10 @@ func CreateUpgradeHandler(
 		// move params from params keeper to each module's store
 		migrateDeprecatedParamsKeeperSubspaces(ctx, keepers)
 		// Initialize endorsements for existing rollapps
-		migrateEndorsements(ctx, keepers.IncentivesKeeper, keepers.SponsorshipKeeper)
+		err = migrateEndorsements(ctx, keepers.IncentivesKeeper, keepers.SponsorshipKeeper)
+		if err != nil {
+			return nil, fmt.Errorf("migrate endorsements: %w", err)
+		}
 
 		/* ----------------------------- params updates ----------------------------- */
 		// Incentives module params migration
@@ -157,19 +161,42 @@ func updateGovParams(ctx sdk.Context, k *govkeeper.Keeper) {
 
 // Create endorsment objects for existing rollapps
 // we iterate over rollapp gauges as we have one per rollapp
-func migrateEndorsements(ctx sdk.Context, incentivesKeeper *incentiveskeeper.Keeper, sponsorshipKeeper *sponsorshipkeeper.Keeper) {
+func migrateEndorsements(ctx sdk.Context, incentivesKeeper *incentiveskeeper.Keeper, sponsorshipKeeper *sponsorshipkeeper.Keeper) error {
 	gauges := incentivesKeeper.GetGauges(ctx)
+	distr, err := sponsorshipKeeper.GetDistribution(ctx)
+	if err != nil {
+		return fmt.Errorf("get distribution: %w", err)
+	}
+
+	// This is a temporary map for a fast lookup of gauge total voting power
+	powerByGauge := make(map[uint64]math.Int, len(distr.Gauges))
+	for _, gauge := range distr.Gauges {
+		powerByGauge[gauge.GaugeId] = gauge.Power
+	}
+
 	for _, gauge := range gauges {
 		if rollappGauge := gauge.GetRollapp(); rollappGauge != nil {
-			// Create endorsement for this rollapp gauge
-			endorsement := sponsorshiptypes.NewEndorsement(rollappGauge.RollappId, gauge.Id)
+			// Check if the gauge has any voting power. Total voting power is the initial
+			// number of shares in the respective endorsement gauge.
+			power, ok := powerByGauge[gauge.Id]
+			if !ok {
+				// If a RA gauge does not have any power, it's fine; use 0.
+				// It means there is no voting power cast to this rollapp.
+				power = math.ZeroInt()
+			}
+
+			// Create an endorsement for this rollapp gauge
+			endorsement := sponsorshiptypes.NewEndorsement(rollappGauge.RollappId, gauge.Id, power)
+
 			err := sponsorshipKeeper.SaveEndorsement(ctx, endorsement)
 			if err != nil {
-				panic(fmt.Errorf("failed to save endorsement: %w", err))
+				return fmt.Errorf("failed to save endorsement: %w", err)
 			}
+
 			ctx.Logger().Info(fmt.Sprintf("Created endorsement for rollapp %s with gauge %d", rollappGauge.RollappId, gauge.Id))
 		}
 	}
+	return nil
 }
 
 // Get params from subspaces and set them using each keeper's SetParams method

--- a/x/sponsorship/types/types.go
+++ b/x/sponsorship/types/types.go
@@ -195,11 +195,11 @@ func (m Gauges) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }
 
-func NewEndorsement(rollappId string, rollappGaugeId uint64) Endorsement {
+func NewEndorsement(rollappId string, rollappGaugeId uint64, totalShares math.Int) Endorsement {
 	return Endorsement{
 		RollappId:      rollappId,
 		RollappGaugeId: rollappGaugeId,
-		TotalShares:    math.ZeroInt(),
+		TotalShares:    totalShares,
 		EpochShares:    math.ZeroInt(),
 	}
 }

--- a/x/streamer/keeper/hooks.go
+++ b/x/streamer/keeper/hooks.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	sponsorshiptypes "github.com/dymensionxyz/dymension/v3/x/sponsorship/types"
 	"github.com/dymensionxyz/sdk-utils/utils/uevent"
 	epochstypes "github.com/osmosis-labs/osmosis/v15/x/epochs/types"
@@ -164,7 +165,8 @@ func (h Hooks) RollappCreated(ctx sdk.Context, rollappID, _ string, _ sdk.AccAdd
 		ctx.Logger().Error("Failed to create rollapp gauge", "error", err)
 		return fmt.Errorf("create rollapp gauge: %w", err)
 	}
-	err = h.k.sk.SaveEndorsement(ctx, sponsorshiptypes.NewEndorsement(rollappID, rollappGaugeId))
+	// Initially, there are no any shares in the endorsement gauge. It will increase with time.
+	err = h.k.sk.SaveEndorsement(ctx, sponsorshiptypes.NewEndorsement(rollappID, rollappGaugeId, math.ZeroInt()))
 	if err != nil {
 		ctx.Logger().Error("Failed to save endorsement", "error", err)
 		return fmt.Errorf("save endorsement: %w", err)


### PR DESCRIPTION
## Description

We need to carefully fill the `TotalShare` setting of endorsements for existing RAs. To do so, we iterate through the distribution gauges and check theirs total voting power. It might be zero if no one endorsed the RA. `TotalShare` equals to the total voting power cast to the RA.

Closes https://github.com/dymensionxyz/audits/issues/32