### PR TITLE
Fix Typos in Proto Comments 

### DIFF
--- a/proto/dymensionxyz/dymension/common/completion_hook.proto
+++ b/proto/dymensionxyz/dymension/common/completion_hook.proto
@@ -3,7 +3,7 @@ package dymensionxyz.dymension.common;
 
 option go_package = "github.com/dymensionxyz/dymension/v3/x/common/types";
 
-// if given in eibc metadata, eibc fullfillment funds will be directed to a module address
+// if given in eibc metadata, eibc fulfillment funds will be directed to a module address
 // and a hook will be executed, and finalize will also call the hook
 // note: only for onRecvPacket
 message CompletionHookCall {

--- a/proto/dymensionxyz/dymension/incentives/genesis.proto
+++ b/proto/dymensionxyz/dymension/incentives/genesis.proto
@@ -15,7 +15,7 @@ message GenesisState {
   // gauges are all gauges that should exist at genesis
   repeated Gauge gauges = 2 [ (gogoproto.nullable) = false ];
   // lockable_durations are all lockup durations that gauges can be locked for
-  // in order to recieve incentives
+  // in order to receive incentives
   repeated google.protobuf.Duration lockable_durations = 3 [
     (gogoproto.nullable) = false,
     (gogoproto.stdduration) = true,


### PR DESCRIPTION
Title:  
Fix Typos in Proto Comments ("fulfillment" and "receive")

Description:  
This pull request corrects two typographical errors in proto files:
- In completion_hook.proto, "fulfillment" was misspelled as "fulfillment".
- In genesis.proto, "receive" was misspelled as "recieve".

These changes improve code documentation clarity and maintain consistency. No functional code changes are included.
