### PR TITLE
Fix minor grammar issues in comments and test assertions

### DIFF
--- a/app/ante/cosmos_handler.go
+++ b/app/ante/cosmos_handler.go
@@ -31,7 +31,7 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 			WithPredicate(BlockTypeUrls(
 				0,
 				sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
-				sdk.MsgTypeURL(&ibcclienttypes.MsgSubmitMisbehaviour{}), // deprecated. not suppose to be used
+				sdk.MsgTypeURL(&ibcclienttypes.MsgSubmitMisbehaviour{}), // deprecated. not supposed to be used
 				sdk.MsgTypeURL(&vestingtypes.MsgCreateVestingAccount{}),
 				sdk.MsgTypeURL(&vestingtypes.MsgCreatePeriodicVestingAccount{}),
 				sdk.MsgTypeURL(&vestingtypes.MsgCreatePermanentLockedAccount{}))),

--- a/app/ante/eip712_test.go
+++ b/app/ante/eip712_test.go
@@ -232,7 +232,7 @@ func (suite *AnteTestSuite) DumpEIP712LegacyTypedData(from sdk.AccAddress, msgs 
 	txConfig := suite.clientCtx.TxConfig
 	suite.txBuilder = txConfig.NewTxBuilder()
 	builder, ok := suite.txBuilder.(authtx.ExtensionOptionsTxBuilder)
-	suite.Require().True(ok, "txBuilder could not be casted to authtx.ExtensionOptionsTxBuilder type")
+	suite.Require().True(ok, "txBuilder could not be cast to authtx.ExtensionOptionsTxBuilder type")
 
 	// chainID
 	pc, err := ethermint.ParseChainID(suite.ctx.ChainID())
@@ -286,7 +286,7 @@ func (suite *AnteTestSuite) DumpEIP712TypedData(from sdk.AccAddress, msgs []sdk.
 	txConfig := suite.clientCtx.TxConfig
 	suite.txBuilder = txConfig.NewTxBuilder()
 	builder, ok := suite.txBuilder.(authtx.ExtensionOptionsTxBuilder)
-	suite.Require().True(ok, "txBuilder could not be casted to authtx.ExtensionOptionsTxBuilder type")
+	suite.Require().True(ok, "txBuilder could not be cast to authtx.ExtensionOptionsTxBuilder type")
 
 	// chainID
 	pc, err := ethermint.ParseChainID(suite.ctx.ChainID())


### PR DESCRIPTION
This PR fixes small grammar issues across two files:

In cosmos_handler.go, corrected the passive form from not suppose to be used to not supposed to be used.

In eip712_test.go, replaced incorrect phrase "could not be casted" with the correct "could not be cast".