### PR TITLE
Fix incorrect link in CHANGELOG entry for rollapp issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,7 +381,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 - (eibc,delayedack) [#942](https://github.com/dymensionxyz/dymension/issues/942) Add missing genesis validation
-- (rollapp) [#317](https://github.com/dymensionxyz/research/issues/317) Prevent overflow on rollapp state update
+- (rollapp) [#317](https://github.com/dymensionxyz/dymension/issues/317) Prevent overflow on rollapp state update
 - (code standards) [#932](https://github.com/dymensionxyz/dymension/issues/932) Dry out existing middlewares to make use of new .GetValidTransfer* functions which take care of parsing and validating the fungible packet, and querying and validating any associated rollapp and finalizations
 - (code standards) [#932](https://github.com/dymensionxyz/dymension/issues/932) Removes the obsolete ValidateRollappId func and sub routines
 - (code standards) [#932](https://github.com/dymensionxyz/dymension/issues/932) Simplify GetAllBlockHeightToFinalizationQueue


### PR DESCRIPTION
Corrected invalid URL in changelog:
Replaced research/issues/317 with the correct link dymension/issues/317.

The previous link pointed to a non-existent repository