### PR TITLE
fix(codec): shorten and consistency in amino names

### DIFF
--- a/x/delayedack/types/codec.go
+++ b/x/delayedack/types/codec.go
@@ -11,7 +11,7 @@ import (
 // LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgFinalizePacket{}, "delayedack/FinalizePacket", nil)
-	cdc.RegisterConcrete(&MsgFinalizePacketByPacketKey{}, "delayedack/MsgFinalizePacketByPacketKey", nil)
+	cdc.RegisterConcrete(&MsgFinalizePacketByPacketKey{}, "delayedack/FinalizeByPacketKey", nil)
 	cdc.RegisterConcrete(&MsgUpdateParams{}, "delayedack/UpdateParams", nil)
 	cdc.RegisterConcrete(Params{}, "delayedack/Params", nil)
 }

--- a/x/incentives/types/codec.go
+++ b/x/incentives/types/codec.go
@@ -10,8 +10,8 @@ import (
 // RegisterCodec registers the necessary x/incentives interfaces and concrete types on the provided
 // LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgCreateGauge{}, "dymensionxyz/dymension/incentives/CreateGauge", nil)
-	cdc.RegisterConcrete(&MsgAddToGauge{}, "dymensionxyz/dymension/incentives/AddToGauge", nil)
+	cdc.RegisterConcrete(&MsgCreateGauge{}, "incentives/CreateGauge", nil)
+	cdc.RegisterConcrete(&MsgAddToGauge{}, "incentives/AddToGauge", nil)
 	cdc.RegisterConcrete(&MsgUpdateParams{}, "incentives/UpdateParams", nil)
 	cdc.RegisterConcrete(Params{}, "incentives/Params", nil)
 }

--- a/x/lockup/types/codec.go
+++ b/x/lockup/types/codec.go
@@ -8,10 +8,10 @@ import (
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgLockTokens{}, "dymensionxyz/dymension/lockup/LockTokens", nil)
-	cdc.RegisterConcrete(&MsgBeginUnlocking{}, "dymensionxyz/dymension/lockup/BeginUnlockPeriodLock", nil)
-	cdc.RegisterConcrete(&MsgExtendLockup{}, "dymensionxyz/dymension/lockup/ExtendLockup", nil)
-	cdc.RegisterConcrete(&MsgForceUnlock{}, "dymensionxyz/dymension/lockup/ForceUnlockTokens", nil)
+	cdc.RegisterConcrete(&MsgLockTokens{}, "lockup/LockTokens", nil)
+	cdc.RegisterConcrete(&MsgBeginUnlocking{}, "lockup/BeginUnlockPeriodLock", nil)
+	cdc.RegisterConcrete(&MsgExtendLockup{}, "lockup/ExtendLockup", nil)
+	cdc.RegisterConcrete(&MsgForceUnlock{}, "lockup/ForceUnlockTokens", nil)
 	cdc.RegisterConcrete(&MsgUpdateParams{}, "lockup/UpdateParams", nil)
 	cdc.RegisterConcrete(Params{}, "lockup/Params", nil)
 }

--- a/x/streamer/types/codec.go
+++ b/x/streamer/types/codec.go
@@ -10,11 +10,11 @@ import (
 // RegisterCodec registers the necessary x/streamer interfaces and concrete types on the provided
 // LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgCreateStream{}, "dymension/CreateStream", nil)
+	cdc.RegisterConcrete(&MsgCreateStream{}, "streamer/CreateStream", nil)
 	cdc.RegisterConcrete(&DistrRecord{}, "streamer/DistrRecord", nil)
-	cdc.RegisterConcrete(&MsgTerminateStream{}, "dymension/TerminateStream", nil)
-	cdc.RegisterConcrete(&MsgReplaceStream{}, "dymension/ReplaceStream", nil)
-	cdc.RegisterConcrete(&MsgUpdateStream{}, "dymension/UpdateStream", nil)
+	cdc.RegisterConcrete(&MsgTerminateStream{}, "streamer/TerminateStream", nil)
+	cdc.RegisterConcrete(&MsgReplaceStream{}, "streamer/ReplaceStream", nil)
+	cdc.RegisterConcrete(&MsgUpdateStream{}, "streamer/UpdateStream", nil)
 	cdc.RegisterConcrete(&MsgUpdateParams{}, "streamer/UpdateParams", nil)
 	cdc.RegisterConcrete(Params{}, "streamer/Params", nil)
 }


### PR DESCRIPTION
amino names needs to be shorter than 39, otherwise issues with ledger might happen

reference: https://github.com/cosmos/cosmos-sdk/issues/10870