### PR TITLE
fix(iro): increase creation fee until cost is positive

### DIFF
--- a/x/iro/keeper/create_plan.go
+++ b/x/iro/keeper/create_plan.go
@@ -162,7 +162,7 @@ func (k Keeper) CreatePlan(ctx sdk.Context, liquidityDenom string, allocatedAmou
 	feeAmt := k.GetParams(ctx).CreationFee
 	cost := plan.BondingCurve.Cost(math.ZeroInt(), feeAmt)
 	if !cost.IsPositive() {
-		return "", errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid cost for fee charge")
+		cost = math.NewInt(1) // charge minimum creation fee
 	}
 
 	feeCostLiquidlyCoin := sdk.NewCoin(plan.LiquidityDenom, cost)


### PR DESCRIPTION
This PR handles the case where the IRO creation fee is too low, so it's truncated to zero and fails.

In this case, we'll charge the minimum possible (1 token)
