### PR TITLE
chore: fix misspelling issues

### DIFF
--- a/proto/dymensionxyz/dymension/incentives/params.proto
+++ b/proto/dymensionxyz/dymension/incentives/params.proto
@@ -68,7 +68,7 @@ message Params {
     AllRollapps = 1;
   }
 
-  // RollappGaugesModes switches between wether rollapp gauge can distribute
+  // RollappGaugesModes switches between whether rollapp gauge can distribute
   // rewards to only active rollapps or all rollapps can get rewards
   RollappGaugesModes rollapp_gauges_mode = 6;
 }

--- a/proto/dymensionxyz/dymension/incentives/query.proto
+++ b/proto/dymensionxyz/dymension/incentives/query.proto
@@ -156,7 +156,7 @@ message UpcomingGaugesPerDenomResponse {
 
 message QueryLockableDurationsRequest {}
 message QueryLockableDurationsResponse {
-  // Time durations that users can lock coins for in order to recieve rewards
+  // Time durations that users can lock coins for in order to receive rewards
   repeated google.protobuf.Duration lockable_durations = 1 [
     (gogoproto.nullable) = false,
     (gogoproto.stdduration) = true,


### PR DESCRIPTION
## Description

This PR fixes minor spelling mistakes in proto documentation comments:

- Corrected `wether` to `whether`.
- Corrected `recieve` to `receive`.

These changes improve the clarity and professionalism of the code documentation.  No logic or functionality is affected.
