### PR TITLE
fix: replace range-over-number with standard for loop in lp_test.go

### DIFF
--- a/x/eibc/keeper/lp_test.go
+++ b/x/eibc/keeper/lp_test.go
@@ -159,7 +159,7 @@ func (suite *KeeperTestSuite) TestLPQueriesByAddr() {
 		"dym1ra6le06p8lle3q6gnsmwz769t2kqld9pmden5k",
 		"dym10j59k4whfvtu5flc3lypsjmcyx3fn57ygw78du",
 	}
-	for i := range 6 {
+	for i := 0; i < 6; i++ {
 		_, err = k.LPs.Create(ctx, &types.OnDemandLP{
 			Rollapp:   "1",
 			Denom:     "bbb",


### PR DESCRIPTION
Replace non-idiomatic `for i := range 6` construction with standard `for i := 0; i < 6; i++` loop pattern. This avoids creating a temporary collection in memory and follows Go best practices for numeric iteration