### PR TITLE
docs(lockup): update TOC anchors in README.md

### DIFF
--- a/x/lockup/README.md
+++ b/x/lockup/README.md
@@ -16,11 +16,11 @@ This module provides interfaces for other modules to iterate the locks efficient
 2. **[State](#state)**
 3. **[Messages](#messages)**
 4. **[Events](#events)**
-5. **[Keeper](#keeper)**
+5. **[Keepers](#keepers)**
 6. **[Hooks](#hooks)**
 7. **[Queries](#queries)**
 8. **[Transactions](#transactions)**
-9. **[Params](#params)**
+9. **[Parameters](#parameters)**
 10. **[Endblocker](#endblocker)**
 
 ## Concepts


### PR DESCRIPTION
## Description
This PR updates the Table of Contents in `x/lockup/README.md` to ensure all links accurately point to the correct sections:

- Fixed anchor from `Keeper` to `Keepers`
- Fixed anchor from `Params` to `Parameters`
- All other TOC entries were checked and aligned with their actual section headings

No logic or functionality is affected.
