### PR TITLE
chore: fix inconsistent struct name in comment

### DIFF
--- a/ibctesting/delayed_ack_test.go
+++ b/ibctesting/delayed_ack_test.go
@@ -243,7 +243,7 @@ func (s *delayedAckSuite) TestHubToRollappTimeout() {
 	s.Require().Equal(preSendBalance.Amount, postFinalizeBalance.Amount)
 }
 
-// TestHardFork tests the hard fork handling for outgoing packets from the hub to the rollapp.
+// TestHardFork_HubToRollapp tests the hard fork handling for outgoing packets from the hub to the rollapp.
 // we assert the packets commitments are restored and the pending packets are ackable after the hard fork.
 func (s *delayedAckSuite) TestHardFork_HubToRollapp() {
 	path := s.newTransferPath(s.hubChain(), s.rollappChain())

--- a/ibctesting/genesis_bridge_test.go
+++ b/ibctesting/genesis_bridge_test.go
@@ -123,7 +123,7 @@ func (s *GenesisBridgeSuite) TestHappyPath_GenesisAccounts() {
 	s.Require().Equal(gAccounts[0].Amount, balance.Amount)
 }
 
-// TestHappyPath_GenesisAccounts_IRO tests a valid genesis info with genesis accounts, including IRO plan
+// TestIRO tests a valid genesis info with genesis accounts, including IRO plan
 // We expect the IRO plan to be settled once the genesis bridge is completed
 func (s *GenesisBridgeSuite) TestIRO() {
 	// fund the rollapp owner account for iro creation fee


### PR DESCRIPTION
## Description

 fix inconsistent struct name in comment

----

Closes #XXX

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x]  Targeted PR against the correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

----

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
