### PR TITLE
fix: Update dymint lint badge to use correct workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 ![license](https://img.shields.io/github/license/dymensionxyz/dymension)
 ![Go](https://img.shields.io/badge/go-1.18-blue.svg)
 ![issues](https://img.shields.io/github/issues/dymensionxyz/dymension)
-![tests](https://github.com/dymensionxyz/dymint/actions/workflows/test.yml/badge.svg?branch=main)
+![tests](https://github.com/dymensionxyz/dymension/actions/workflows/test.yml/badge.svg?branch=main)
 ![lint](https://github.com/dymensionxyz/dymension/actions/workflows/golangci_lint.yml/badge.svg?branch=main)
 
 ## Overview

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ![Go](https://img.shields.io/badge/go-1.18-blue.svg)
 ![issues](https://img.shields.io/github/issues/dymensionxyz/dymension)
 ![tests](https://github.com/dymensionxyz/dymint/actions/workflows/test.yml/badge.svg?branch=main)
-![lint](https://github.com/dymensionxyz/roller/actions/workflows/lint.yml/badge.svg?branch=main)
+![lint](https://github.com/dymensionxyz/dymension/actions/workflows/golangci_lint.yml/badge.svg?branch=main)
 
 ## Overview
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ![Go](https://img.shields.io/badge/go-1.18-blue.svg)
 ![issues](https://img.shields.io/github/issues/dymensionxyz/dymension)
 ![tests](https://github.com/dymensionxyz/dymint/actions/workflows/test.yml/badge.svg?branch=main)
-![lint](https://github.com/dymensionxyz/dymint/actions/workflows/lint.yml/badge.svg?branch=main)
+![lint](https://github.com/dymensionxyz/roller/actions/workflows/lint.yml/badge.svg?branch=main)
 
 ## Overview
 


### PR DESCRIPTION


### Changes
- **Before:** `dymint/actions/workflows/lint.yml` (404 error)
- **After:** `roller/actions/workflows/lint.yml` (working badge)

### Why
The original badge was pointing to a non-existent workflow in the dymint repository. Updated to use the correct roller repository workflow.

