### PR TITLE
fix(lightclient): avoid all consensus states iter

### DIFF
--- a/x/lightclient/keeper/canonical_client.go
+++ b/x/lightclient/keeper/canonical_client.go
@@ -124,7 +124,10 @@ func (k Keeper) validClient(ctx sdk.Context, clientID string, cs *ibctm.ClientSt
 	if !ok {
 		return gerrc.ErrNotFound.Wrap("latest state info index")
 	}
-	baseHeight := k.GetFirstConsensusStateHeight(ctx, clientID)
+	baseHeight, err := k.GetFirstConsensusStateHeight(ctx, clientID)
+	if err != nil {
+		return errorsmod.Wrap(err, "get first consensus state height")
+	}
 	atLeastOneMatch := false
 	for i := sinfo.Index; i > 0; i-- {
 		sInfo, ok := k.rollappKeeper.GetStateInfo(ctx, rollappId, i)

--- a/x/lightclient/keeper/client_store.go
+++ b/x/lightclient/keeper/client_store.go
@@ -110,7 +110,7 @@ func deleteIterationKey(clientStore storetypes.KVStore, height exported.Height) 
 }
 
 // GetFirstHeight returns the lowest height available for a client.
-func (k Keeper) GetFirstConsensusStateHeight(ctx sdk.Context, clientID string) uint64 {
+func (k Keeper) GetFirstConsensusStateHeight(ctx sdk.Context, clientID string) (uint64, error) {
 	clientStore := k.ibcClientKeeper.ClientStore(ctx, clientID)
 	var height exported.Height
 
@@ -120,9 +120,9 @@ func (k Keeper) GetFirstConsensusStateHeight(ctx sdk.Context, clientID string) u
 	})
 
 	if height == nil {
-		return 0
+		return 0, clienttypes.ErrConsensusStateNotFound
 	}
-	return height.GetRevisionHeight()
+	return height.GetRevisionHeight(), nil
 }
 
 // copied from ibc-go/modules/light-clients/07-tendermint/update.go

--- a/x/lightclient/keeper/client_store.go
+++ b/x/lightclient/keeper/client_store.go
@@ -111,14 +111,17 @@ func deleteIterationKey(clientStore storetypes.KVStore, height exported.Height) 
 
 // GetFirstHeight returns the lowest height available for a client.
 func (k Keeper) GetFirstConsensusStateHeight(ctx sdk.Context, clientID string) uint64 {
-	height := clienttypes.Height{}
-	k.ibcClientKeeper.IterateConsensusStates(ctx, func(id string, cs clienttypes.ConsensusStateWithHeight) bool {
-		if id != clientID {
-			return false
-		}
-		height = cs.Height
-		return true
+	clientStore := k.ibcClientKeeper.ClientStore(ctx, clientID)
+	var height exported.Height
+
+	ibctm.IterateConsensusStateAscending(clientStore, func(h exported.Height) (stop bool) {
+		height = h
+		return true // stop after first iteration
 	})
+
+	if height == nil {
+		return 0
+	}
 	return height.GetRevisionHeight()
 }
 


### PR DESCRIPTION
…nsive iteration

The previous implementation was iterating over ALL consensus states across all clients using k.ibcClientKeeper.IterateConsensusStates, which is inefficient when only needing the first height for a specific client.

This change uses ibctm.IterateConsensusStateAscending to iterate only over the consensus states for the specific client and stops after the first one, significantly improving performance.

Fixes #1958

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

----

Closes #XXX

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ]  Targeted PR against the correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

----

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
