### PR TITLE
chore: Fix typos and parameter naming in incentives and forward modules

### DIFF
--- a/x/forward/hyperlane.go
+++ b/x/forward/hyperlane.go
@@ -91,7 +91,7 @@ func (k Forward) forwardToHyperlane(ctx sdk.Context, fundsSrc sdk.AccAddress, bu
 		CustomHookId:       d.HyperlaneTransfer.CustomHookId,
 	}
 
-	_, err = k.warpS.RemoteTransfer(ctx, m) // TODO: responsse?
+	_, err = k.warpS.RemoteTransfer(ctx, m) // TODO: response?
 	return errorsmod.Wrap(err, "dym remote transfer")
 }
 

--- a/x/incentives/keeper/export_test.go
+++ b/x/incentives/keeper/export_test.go
@@ -12,8 +12,8 @@ func (k Keeper) AddGaugeRefByKey(ctx sdk.Context, key []byte, gaugeID uint64) er
 }
 
 // DeleteGaugeRefByKey removes the provided gauge ID from an array associated with the provided key.
-func (k Keeper) DeleteGaugeRefByKey(ctx sdk.Context, key []byte, guageID uint64) error {
-	return k.deleteGaugeRefByKey(ctx, key, guageID)
+func (k Keeper) DeleteGaugeRefByKey(ctx sdk.Context, key []byte, gaugeID uint64) error {
+	return k.deleteGaugeRefByKey(ctx, key, gaugeID)
 }
 
 // GetGaugeRefs returns the gauge IDs specified by the provided key.
@@ -26,7 +26,7 @@ func (k Keeper) GetAllGaugeIDsByDenom(ctx sdk.Context, denom string) []uint64 {
 	return k.getGaugeRefs(ctx, gaugeDenomStoreKey(denom))
 }
 
-// MoveUpcomingGaugeToActiveGauge moves a gauge that has reached it's start time from an upcoming to an active status.
+// MoveUpcomingGaugeToActiveGauge moves a gauge that has reached its start time from an upcoming to an active status.
 func (k Keeper) MoveUpcomingGaugeToActiveGauge(ctx sdk.Context, gauge types.Gauge) error {
 	return k.moveUpcomingGaugeToActiveGauge(ctx, gauge)
 }


### PR DESCRIPTION
Corrected typo in comment in x/forward/hyperlane.go: fixed "responsse" to "response".

Fixed parameter name typo in x/incentives/keeper/export_test.go from guageID to gaugeID in DeleteGaugeRefByKey method.

Fixed typo in comment for MoveUpcomingGaugeToActiveGauge method: changed "it's" to "its".