### PR TITLE
fix(sequencer): prevent self-kick to avoid state inconsistency

### DIFF
--- a/x/sequencer/keeper/fraud.go
+++ b/x/sequencer/keeper/fraud.go
@@ -21,6 +21,11 @@ func (k Keeper) TryKickProposer(ctx sdk.Context, kicker types.Sequencer) error {
 
 	proposer := k.GetProposer(ctx, ra)
 
+	// Prevent self-kick: kicker cannot be the current proposer
+	if kicker.Address == proposer.Address {
+		return errorsmod.Wrap(gerrc.ErrPermissionDenied, "sequencer cannot kick itself")
+	}
+
 	if !k.Kickable(ctx, proposer) {
 		return errorsmod.Wrap(gerrc.ErrFailedPrecondition, "not kickable")
 	}

--- a/x/sequencer/keeper/msg_server_kick_proposer.go
+++ b/x/sequencer/keeper/msg_server_kick_proposer.go
@@ -3,10 +3,8 @@ package keeper
 import (
 	"context"
 
-	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dymensionxyz/dymension/v3/x/sequencer/types"
-	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 func (k msgServer) KickProposer(goCtx context.Context, msg *types.MsgKickProposer) (*types.MsgKickProposerResponse, error) {
@@ -15,12 +13,6 @@ func (k msgServer) KickProposer(goCtx context.Context, msg *types.MsgKickPropose
 	kicker, err := k.RealSequencer(ctx, msg.GetCreator())
 	if err != nil {
 		return nil, err
-	}
-
-	// Prevent self-kick: kicker cannot be the current proposer
-	proposer := k.GetProposer(ctx, kicker.RollappId)
-	if kicker.Address == proposer.Address {
-		return nil, errorsmod.Wrap(gerrc.ErrFailedPrecondition, "sequencer cannot kick itself")
 	}
 
 	if err := k.TryKickProposer(ctx, kicker); err != nil {

--- a/x/sequencer/keeper/msg_server_kick_proposer.go
+++ b/x/sequencer/keeper/msg_server_kick_proposer.go
@@ -3,8 +3,10 @@ package keeper
 import (
 	"context"
 
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dymensionxyz/dymension/v3/x/sequencer/types"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 func (k msgServer) KickProposer(goCtx context.Context, msg *types.MsgKickProposer) (*types.MsgKickProposerResponse, error) {
@@ -13,6 +15,12 @@ func (k msgServer) KickProposer(goCtx context.Context, msg *types.MsgKickPropose
 	kicker, err := k.RealSequencer(ctx, msg.GetCreator())
 	if err != nil {
 		return nil, err
+	}
+
+	// Prevent self-kick: kicker cannot be the current proposer
+	proposer := k.GetProposer(ctx, kicker.RollappId)
+	if kicker.Address == proposer.Address {
+		return nil, errorsmod.Wrap(gerrc.ErrFailedPrecondition, "sequencer cannot kick itself")
 	}
 
 	if err := k.TryKickProposer(ctx, kicker); err != nil {

--- a/x/sequencer/keeper/msg_server_kick_proposer_test.go
+++ b/x/sequencer/keeper/msg_server_kick_proposer_test.go
@@ -57,37 +57,37 @@ func (s *SequencerTestSuite) TestKickProposerSelfKickPrevented() {
 	ra := s.createRollapp()
 	seqAlice := s.createSequencerWithBond(s.Ctx, ra.RollappId, alice, bond)
 	s.Require().True(s.k().IsProposer(s.Ctx, seqAlice))
-	
+
 	// Submit some state updates to avoid hard fork issues
 	s.submitAFewRollappStates(ra.RollappId)
-	
+
 	// Make alice kickable by setting penalty to threshold
 	seqAlice.SetPenalty(types.DefaultDishonorKickThreshold)
 	s.k().SetSequencer(s.Ctx, seqAlice)
-	
+
 	// Alice tries to kick herself (self-kick)
 	m := &types.MsgKickProposer{Creator: pkAddr(alice)}
 	_, err := s.msgServer.KickProposer(s.Ctx, m)
-	
+
 	// Self-kick should be prevented
-	utest.IsErr(s.Require(), err, gerrc.ErrFailedPrecondition)
+	utest.IsErr(s.Require(), err, gerrc.ErrPermissionDenied)
 	s.Require().Contains(err.Error(), "sequencer cannot kick itself")
-	
+
 	// Alice should still be the proposer
 	s.Require().True(s.k().IsProposer(s.Ctx, seqAlice))
-	
+
 	// Alice should still be bonded
 	seqAliceAfter := s.k().GetSequencer(s.Ctx, seqAlice.Address)
 	s.Require().Equal(types.Bonded, seqAliceAfter.Status)
-	
+
 	// Create another sequencer (Bob) who can properly kick Alice
 	seqBob := s.createSequencerWithBond(s.Ctx, ra.RollappId, bob, bond)
-	
+
 	// Bob successfully kicks Alice
 	mBob := &types.MsgKickProposer{Creator: pkAddr(bob)}
 	_, err = s.msgServer.KickProposer(s.Ctx, mBob)
 	s.Require().NoError(err)
-	
+
 	// Bob is now proposer
 	s.Require().True(s.k().IsProposer(s.Ctx, seqBob))
 	s.Require().False(s.k().IsProposer(s.Ctx, seqAlice))


### PR DESCRIPTION
## Summary
- Prevents sequencers from kicking themselves to avoid state inconsistency
- Adds validation check that kicker != proposer before allowing kick operation
- Includes comprehensive test coverage for the self-kick prevention

## Problem
When a sequencer kicks itself (self-kick), a critical bug occurs due to using a stale copy of the sequencer object in `TryKickProposer`. The flow is:

1. The kicker object is loaded at the beginning of `TryKickProposer`
2. `abruptRemoveProposer` unbonds the sequencer (since kicker == proposer)
3. Hard fork and hooks execute, potentially modifying sequencer state
4. The STALE kicker object (still showing as bonded) is opted in and saved back
5. This overwrites the unbonded status, keeping the kicked sequencer as bonded and proposer

This was discovered when a self-kicked sequencer remained as proposer even after being kicked.

## Solution
Added a simple validation in `msgServer.KickProposer` to prevent self-kick entirely:
- Check if kicker.Address == proposer.Address
- Return error if they match
- This prevents the entire problematic flow from executing

## Test Plan
- [x] Added test `TestKickProposerSelfKickPrevented` that verifies:
  - Self-kick attempts are rejected with appropriate error
  - Sequencer remains proposer and bonded after failed self-kick
  - Another sequencer can still properly kick the proposer
- [x] All existing tests pass

## Related Issues
Discovered during investigation of sequencer kick issues on playground network.

🤖 Generated with [Claude Code](https://claude.ai/code)