### PR TITLE
fix(cmd): correct typos and grammar in dymd command files

### DIFF
--- a/cmd/dymd/cmd/config.go
+++ b/cmd/dymd/cmd/config.go
@@ -20,7 +20,7 @@ func initSDKConfig() {
 	RegisterDenoms()
 }
 
-// RegisterDenoms registers the base and display denominations to the SDK.
+// RegisterDenoms registers the base and displays denominations to the SDK.
 func RegisterDenoms() {
 	if err := sdk.RegisterDenom(appparams.DisplayDenom, math.LegacyOneDec()); err != nil {
 		panic(err)

--- a/cmd/dymd/cmd/debug.go
+++ b/cmd/dymd/cmd/debug.go
@@ -58,7 +58,7 @@ func PubkeyCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "pubkey [pubkey]",
 		Short: "Decode a pubkey from proto JSON",
-		Long:  "Decode a pubkey from proto JSON and display it's address",
+		Long:  "Decode a pubkey from proto JSON and display its address",
 		Example: fmt.Sprintf(
 			`"$ %s debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ"}'`, //gitleaks:allow
 			version.AppName,

--- a/cmd/dymd/cmd/root.go
+++ b/cmd/dymd/cmd/root.go
@@ -155,7 +155,7 @@ ______   __   __  __   __  _______  __    _  _______  ___   _______  __    _    
 	autoCliOpts.ClientCtx = initClientCtx
 
 	// a workaround to wire the legacy proposals to the cli
-	// autoCli uses AppModule, while the legacy proposals registered on the AppModuleBasic
+	// autoCli uses AppModule, while the legacy proposals are registered on the AppModuleBasic
 	govModule, ok := autoCliOpts.Modules["gov"].(gov.AppModule)
 	if !ok {
 		panic("gov module not found")


### PR DESCRIPTION
- config.go: "display denominations" → "displays denominations"
- debug.go: fixed possessive typo "it's address" → "its address"
- root.go: clarified comment grammar  
  - "legacy proposals registered" → "legacy proposals are registered"