### PR TITLE
fix: correct error message for relayer validation in RollappPacket

### DIFF
--- a/utils/uinv/funcs.go
+++ b/utils/uinv/funcs.go
@@ -42,7 +42,7 @@ func (nf NamedFunc[K]) Exec(ctx sdk.Context, module string, keeper K) (string, b
 		broken = errorsmod.IsOf(err, ErrBroken)
 		if !broken {
 			ctx.Logger().Error("Invariant function error but not breaking.", "module", module, "name", nf.Name, "error", err)
-			// Note that if it is broken the SDK wil take care of logging the error somewhere else
+			// Note that if it is broken the SDK will take care of logging the error somewhere else
 		}
 		msg = sdk.FormatInvariant(module, nf.Name, err.Error())
 	}

--- a/x/common/types/rollapp_packet.go
+++ b/x/common/types/rollapp_packet.go
@@ -19,7 +19,7 @@ func (r RollappPacket) ValidateBasic() error {
 		return fmt.Errorf("rollapp id cannot be empty")
 	}
 	if len(r.Relayer) == 0 {
-		return fmt.Errorf("status cannot be empty")
+		return fmt.Errorf("relayer cannot be empty")
 	}
 	if r.OriginalTransferTarget != "" {
 		if _, err := sdk.AccAddressFromBech32(r.OriginalTransferTarget); err != nil {


### PR DESCRIPTION
Fix incorrect error message in RollappPacket.ValidateBasic() method.
The validation checks for empty relayer but returns "status cannot be empty" 
error message. Updated to return "relayer cannot be empty" to match the 
actual validation logic.

also fixed typo