### PR TITLE
Go version alignment

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine3.21 as go-builder
+FROM golang:1.24-alpine3.21 as go-builder
 
 ARG LINK_STATICALLY
 

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ docker-run-debug:
 ###############################################################################
 
 PACKAGE_NAME:=github.com/dymensionxyz/dymension
-GOLANG_CROSS_VERSION  = v1.22
+GOLANG_CROSS_VERSION  = v1.24
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \


### PR DESCRIPTION
## Description

Align Go version across build surfaces to 1.24:

- Dockerfile.debug: golang:1.23 → golang:1.24 (alpine3.21)
- Makefile: GOLANG_CROSS_VERSION v1.22 → v1.24
- go.mod already declares go 1.24.6; main Dockerfile already uses golang:1.24
