### PR TITLE
fix(ci): free up disk space task

### DIFF
--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -1,34 +1,28 @@
----
 name: Release Binary
-
 on:
   release:
     types: [created]
-      
 permissions: write-all
-
 # This workflow creates a release using goreleaser
 # via the 'make release' command.
-
 jobs:
   release:
     runs-on: ubuntu-latest
     environment: release
     steps:
+      - name: Free disk space
+        run: curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
       - name: Setup release environment
         run: |-
           echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
-
       - name: Release publish
         run: make release


### PR DESCRIPTION
the last binary release for latest rc failed due to the hosted workers not having enough space to download go dependencies. 
https://github.com/dymensionxyz/dymension/actions/runs/18222417075/job/51887515528

this PR adds a script which removes unused/unnecessary data from the worker file system before starting the release process.
