### PR TITLE
fix(streamer): show pump pressure only for top rollapps

### DIFF
--- a/x/streamer/keeper/grpc_query.go
+++ b/x/streamer/keeper/grpc_query.go
@@ -111,13 +111,10 @@ func (q Querier) PumpPressure(goCtx context.Context, req *types.PumpPressureRequ
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	d, err := q.sk.GetDistribution(ctx)
+	pressure, err := q.TotalPumpPressure(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
-
-	totalPressure := q.TotalPumpBudget(ctx)
-	pressure := q.TopRollapps(ctx, d.Gauges, totalPressure, nil, nil)
 
 	return &types.PumpPressureResponse{
 		Pressure:   pressure,
@@ -133,13 +130,11 @@ func (q Querier) PumpPressureByRollapp(goCtx context.Context, req *types.PumpPre
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	d, err := q.sk.GetDistribution(ctx)
+	pressure, err := q.TotalPumpPressure(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	totalPressure := q.TotalPumpBudget(ctx)
-	pressure := q.TopRollapps(ctx, d.Gauges, totalPressure, nil, nil)
 	idx := slices.IndexFunc(pressure, func(p types.PumpPressure) bool {
 		return p.RollappId == req.RollappId
 	})

--- a/x/streamer/keeper/grpc_query_test.go
+++ b/x/streamer/keeper/grpc_query_test.go
@@ -304,7 +304,7 @@ func (s *KeeperTestSuite) TestPumpPressure() {
 		StartTime:         time.Now(),
 		EpochIdentifier:   "day",
 		NumEpochsPaidOver: 30,
-	}, 1, types.PumpDistr_PUMP_DISTR_UNIFORM, false, types.PumpTargetRollapps(1))
+	}, 1, types.PumpDistr_PUMP_DISTR_UNIFORM, false, types.PumpTargetRollapps(2))
 	s.Ctx = s.Ctx.WithBlockTime(stream.StartTime.Add(time.Second))
 	err = s.App.StreamerKeeper.MoveUpcomingStreamToActiveStream(s.Ctx, *stream)
 	s.Require().NoError(err)

--- a/x/streamer/types/top_rollapps.go
+++ b/x/streamer/types/top_rollapps.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"slices"
+)
+
+// MergeTopRollApps merges multiple slices of PumpPressure that maintain the same rollapp order.
+// When rollapp IDs match, it sums the pressure values.
+// Entries with zero pressure are filtered out.
+// Contract: all input slices maintain the same relative order of rollapps (all are prefixes
+// of the same original sorted list, e.g., top 5 and top 10 from the same source)
+// O(k*n) where k is the number of slices and n is the average length.
+func MergeTopRollApps(top ...[]PumpPressure) []PumpPressure {
+	if len(top) == 0 {
+		return []PumpPressure{}
+	}
+	if len(top) == 1 {
+		return filterZeroPressure(top[0])
+	}
+
+	// Merge all slices sequentially
+	result := top[0]
+	for i := 1; i < len(top); i++ {
+		result = mergeTwoTopRollApps(result, top[i])
+	}
+	return result
+}
+
+// mergeTwoTopRollApps merges two slices of PumpPressure that maintain the same rollapp order.
+// O(n+m) solution based on modified merge algorithm.
+func mergeTwoTopRollApps(lhs, rhs []PumpPressure) []PumpPressure {
+	var (
+		result = make([]PumpPressure, 0, len(lhs)+len(rhs))
+		i      = 0 // first iterator
+		j      = 0 // second iterator
+	)
+
+	for i < len(lhs) && j < len(rhs) {
+		var pump PumpPressure
+		switch {
+		case lhs[i].RollappId == rhs[j].RollappId:
+			pump = PumpPressure{
+				RollappId: lhs[i].RollappId,
+				Pressure:  lhs[i].Pressure.Add(rhs[j].Pressure),
+			}
+			i++
+			j++
+		case lhs[i].RollappId < rhs[j].RollappId:
+			pump = lhs[i]
+			i++
+		case lhs[i].RollappId > rhs[j].RollappId:
+			pump = rhs[j]
+			j++
+		}
+		// Don't store pumps with 0 pressure
+		if !pump.Pressure.IsZero() {
+			result = append(result, pump)
+		}
+	}
+
+	if i != len(lhs) {
+		result = append(result, lhs[i:]...)
+	}
+	if j != len(rhs) {
+		result = append(result, rhs[j:]...)
+	}
+
+	return slices.Clip(result)
+}
+
+// filterZeroPressure removes entries with zero pressure from the slice
+func filterZeroPressure(pumps []PumpPressure) []PumpPressure {
+	result := make([]PumpPressure, 0, len(pumps))
+	for _, p := range pumps {
+		if !p.Pressure.IsZero() {
+			result = append(result, p)
+		}
+	}
+	return slices.Clip(result)
+}

--- a/x/streamer/types/top_rollapps_test.go
+++ b/x/streamer/types/top_rollapps_test.go
@@ -1,0 +1,319 @@
+package types_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+
+	"github.com/dymensionxyz/dymension/v3/x/streamer/types"
+)
+
+func TestMergeTopRollApps(t *testing.T) {
+	tests := []struct {
+		name string
+		tops [][]types.PumpPressure
+		want []types.PumpPressure
+	}{
+		{
+			name: "no slices",
+			tops: [][]types.PumpPressure{},
+			want: []types.PumpPressure{},
+		},
+		{
+			name: "single slice",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+			},
+		},
+		{
+			name: "single slice with zero pressure",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(0)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+			},
+		},
+		{
+			name: "both empty",
+			tops: [][]types.PumpPressure{{}, {}},
+			want: []types.PumpPressure{},
+		},
+		{
+			name: "left empty",
+			tops: [][]types.PumpPressure{
+				{},
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+			},
+		},
+		{
+			name: "right empty",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+			},
+		},
+		{
+			name: "no overlap - interleaved",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				},
+				{
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+					{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+			},
+		},
+		{
+			name: "no overlap - all lhs before rhs",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+					{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+			},
+		},
+		{
+			name: "complete overlap - same rollapp IDs",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(50)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(150)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(150)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(350)},
+			},
+		},
+		{
+			name: "partial overlap",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				},
+				{
+					{RollappId: "rollapp_2", Pressure: math.NewInt(50)},
+					{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(250)},
+				{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+			},
+		},
+		{
+			name: "zero pressure filtered out - from merge",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(-100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(50)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_2", Pressure: math.NewInt(250)},
+			},
+		},
+		{
+			name: "zero pressure in input - not included",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(0)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+			},
+		},
+		{
+			name: "negative pressures",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(-100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(-50)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(-150)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+			},
+		},
+		{
+			name: "complex scenario with multiple overlaps",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+					{RollappId: "rollapp_5", Pressure: math.NewInt(500)},
+					{RollappId: "rollapp_7", Pressure: math.NewInt(700)},
+				},
+				{
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(30)},
+					{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+					{RollappId: "rollapp_5", Pressure: math.NewInt(-500)},
+					{RollappId: "rollapp_6", Pressure: math.NewInt(600)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				{RollappId: "rollapp_3", Pressure: math.NewInt(330)},
+				{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+				{RollappId: "rollapp_6", Pressure: math.NewInt(600)},
+				{RollappId: "rollapp_7", Pressure: math.NewInt(700)},
+			},
+		},
+		{
+			name: "three slices - no overlap",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				},
+				{
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+			},
+		},
+		{
+			name: "three slices - with overlap",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+				},
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(50)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				},
+				{
+					{RollappId: "rollapp_2", Pressure: math.NewInt(25)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(75)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(150)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(225)},
+				{RollappId: "rollapp_3", Pressure: math.NewInt(375)},
+			},
+		},
+		{
+			name: "four slices - complex",
+			tops: [][]types.PumpPressure{
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(100)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(300)},
+				},
+				{
+					{RollappId: "rollapp_2", Pressure: math.NewInt(200)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(30)},
+				},
+				{
+					{RollappId: "rollapp_1", Pressure: math.NewInt(10)},
+					{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+				},
+				{
+					{RollappId: "rollapp_2", Pressure: math.NewInt(20)},
+					{RollappId: "rollapp_3", Pressure: math.NewInt(-330)},
+				},
+			},
+			want: []types.PumpPressure{
+				{RollappId: "rollapp_1", Pressure: math.NewInt(110)},
+				{RollappId: "rollapp_2", Pressure: math.NewInt(220)},
+				{RollappId: "rollapp_4", Pressure: math.NewInt(400)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := types.MergeTopRollApps(tt.tops...)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("MergeTopRollApps() length = %v, want %v", len(got), len(tt.want))
+				return
+			}
+
+			for i := range got {
+				if got[i].RollappId != tt.want[i].RollappId {
+					t.Errorf("MergeTopRollApps()[%d].RollappId = %v, want %v", i, got[i].RollappId, tt.want[i].RollappId)
+				}
+				if !got[i].Pressure.Equal(tt.want[i].Pressure) {
+					t.Errorf("MergeTopRollApps()[%d].Pressure = %v, want %v", i, got[i].Pressure, tt.want[i].Pressure)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
> Vote to pump calculation is incorrect. a lot of the rollapps that shows how much dym they are projected to get are not in the top X rollapps. so for example, when creating pump stream you define top rollapps, but the UI shows as if all rollpps with vote will get pump which is incorrect and takes from the top X rollapps their pump pressure

DRAFT: ADD MORE TESTS