### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/app/upgrades/v5/types/delayedack/params.go
+++ b/app/upgrades/v5/types/delayedack/params.go
@@ -80,7 +80,7 @@ func (p Params) Validate() error {
 	return nil
 }
 
-func validateEpochIdentifier(i interface{}) error {
+func validateEpochIdentifier(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -91,7 +91,7 @@ func validateEpochIdentifier(i interface{}) error {
 	return nil
 }
 
-func validateBridgingFee(i interface{}) error {
+func validateBridgingFee(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -102,7 +102,7 @@ func validateBridgingFee(i interface{}) error {
 	return nil
 }
 
-func validateDeletePacketsEpochLimit(i interface{}) error {
+func validateDeletePacketsEpochLimit(i any) error {
 	v, ok := i.(int32)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/app/upgrades/v5/types/dymns/params.go
+++ b/app/upgrades/v5/types/dymns/params.go
@@ -250,7 +250,7 @@ func (m MiscParams) Validate() error {
 }
 
 // validateEpochIdentifier checks if the given epoch identifier is valid.
-func validateEpochIdentifier(i interface{}) error {
+func validateEpochIdentifier(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -267,7 +267,7 @@ func validateEpochIdentifier(i interface{}) error {
 }
 
 // validatePriceParams checks if the given PriceParams are valid.
-func validatePriceParams(i interface{}) error {
+func validatePriceParams(i any) error {
 	m, ok := i.(PriceParams)
 	if !ok {
 		return errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid parameter type: %T", i)
@@ -380,7 +380,7 @@ func validateAliasPriceParams(m PriceParams) error {
 }
 
 // validateChainsParams checks if the given ChainsParams are valid.
-func validateChainsParams(i interface{}) error {
+func validateChainsParams(i any) error {
 	m, ok := i.(ChainsParams)
 	if !ok {
 		return errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid parameter type: %T", i)
@@ -434,7 +434,7 @@ func validateAliasesOfChainIds(aliasesOfChainIds []AliasesOfChainId) error {
 }
 
 // validateMiscParams checks if the given MiscParams are valid.
-func validateMiscParams(i interface{}) error {
+func validateMiscParams(i any) error {
 	m, ok := i.(MiscParams)
 	if !ok {
 		return errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid parameter type: %T", i)

--- a/app/upgrades/v5/types/eibc/params.go
+++ b/app/upgrades/v5/types/eibc/params.go
@@ -48,7 +48,7 @@ func (p Params) String() string {
 	return string(out)
 }
 
-func validateEpochIdentifier(i interface{}) error {
+func validateEpochIdentifier(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -59,7 +59,7 @@ func validateEpochIdentifier(i interface{}) error {
 	return nil
 }
 
-func validateTimeoutFee(i interface{}) error {
+func validateTimeoutFee(i any) error {
 	v, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/app/upgrades/v5/types/incentives/params.go
+++ b/app/upgrades/v5/types/incentives/params.go
@@ -71,7 +71,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	}
 }
 
-func validateCreateGaugeFeeInterface(i interface{}) error {
+func validateCreateGaugeFeeInterface(i any) error {
 	v, ok := i.(math.Int)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -82,7 +82,7 @@ func validateCreateGaugeFeeInterface(i interface{}) error {
 	return nil
 }
 
-func validateAddToGaugeFeeInterface(i interface{}) error {
+func validateAddToGaugeFeeInterface(i any) error {
 	v, ok := i.(math.Int)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -93,7 +93,7 @@ func validateAddToGaugeFeeInterface(i interface{}) error {
 	return nil
 }
 
-func validateAddDenomFee(i interface{}) error {
+func validateAddDenomFee(i any) error {
 	v, ok := i.(math.Int)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/app/upgrades/v5/types/lockup/params.go
+++ b/app/upgrades/v5/types/lockup/params.go
@@ -43,7 +43,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	}
 }
 
-func validateAddresses(i interface{}) error {
+func validateAddresses(i any) error {
 	addresses, ok := i.([]string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/app/upgrades/v5/types/rollapp/params.go
+++ b/app/upgrades/v5/types/rollapp/params.go
@@ -120,7 +120,7 @@ func (p Params) Validate() error {
 	return nil
 }
 
-func validateDisputePeriodInBlocks(i interface{}) error {
+func validateDisputePeriodInBlocks(i any) error {
 	v, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -131,7 +131,7 @@ func validateDisputePeriodInBlocks(i interface{}) error {
 	return nil
 }
 
-func validateLivenessSlashBlocks(i interface{}) error {
+func validateLivenessSlashBlocks(i any) error {
 	v, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -142,7 +142,7 @@ func validateLivenessSlashBlocks(i interface{}) error {
 	return nil
 }
 
-func validateLivenessSlashInterval(i interface{}) error {
+func validateLivenessSlashInterval(i any) error {
 	v, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -153,7 +153,7 @@ func validateLivenessSlashInterval(i interface{}) error {
 	return nil
 }
 
-func validateAppRegistrationFee(i interface{}) error {
+func validateAppRegistrationFee(i any) error {
 	v, ok := i.(sdk.Coin)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -164,7 +164,7 @@ func validateAppRegistrationFee(i interface{}) error {
 	return nil
 }
 
-func validateMinSequencerBondGlobal(i interface{}) error {
+func validateMinSequencerBondGlobal(i any) error {
 	v, ok := i.(sdk.Coin)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/app/upgrades/v5/types/streamer/params.go
+++ b/app/upgrades/v5/types/streamer/params.go
@@ -62,7 +62,7 @@ func (p Params) Validate() error {
 	return nil
 }
 
-func validateMaxIterationsPerBlock(i interface{}) error {
+func validateMaxIterationsPerBlock(i any) error {
 	v, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/cmd/dymd/cmd/root.go
+++ b/cmd/dymd/cmd/root.go
@@ -68,7 +68,7 @@ var (
 type EmptyAppOptions struct{}
 
 // Get implements AppOptions
-func (ao EmptyAppOptions) Get(o string) interface{} {
+func (ao EmptyAppOptions) Get(o string) any {
 	return nil
 }
 
@@ -188,7 +188,7 @@ func initCometBFTConfig() *cmtcfg.Config {
 
 // initAppConfig helps to override default appConfig template and configs.
 // return "", nil if no custom configuration is required for the application.
-func initAppConfig() (string, interface{}) {
+func initAppConfig() (string, any) {
 	baseDenom, err := sdk.GetBaseDenom()
 	if err != nil {
 		panic(err)

--- a/testutil/math/math.go
+++ b/testutil/math/math.go
@@ -29,7 +29,7 @@ func LogarithmicRangeForRapid(t *rapid.T, min, max int64) int64 {
 }
 
 // ApproxEqual checks if two values of different types are approximately equal
-func ApproxEqual(expected, actual, allowed_diff interface{}) error {
+func ApproxEqual(expected, actual, allowed_diff any) error {
 	switch e := expected.(type) {
 	case sdkmath.LegacyDec:
 		a, ok := actual.(sdkmath.LegacyDec)
@@ -66,7 +66,7 @@ func ApproxEqual(expected, actual, allowed_diff interface{}) error {
 }
 
 // ApproxEqualRatio checks if two values of different types are approximately equal
-func ApproxEqualRatio(expected, actual interface{}, allowed_ratio_diff float64) error {
+func ApproxEqualRatio(expected, actual any, allowed_ratio_diff float64) error {
 	switch e := expected.(type) {
 	case sdkmath.LegacyDec:
 		a, ok := actual.(sdkmath.LegacyDec)

--- a/testutil/nullify/nullify.go
+++ b/testutil/nullify/nullify.go
@@ -16,7 +16,7 @@ var (
 // Fill analyzes all struct fields and slices with
 // reflection and initialize the nil and empty slices,
 // structs, and pointers.
-func Fill(x interface{}) interface{} {
+func Fill(x any) any {
 	v := reflect.Indirect(reflect.ValueOf(x))
 	switch v.Kind() {
 	case reflect.Slice:

--- a/x/delayedack/keeper/fraud.go
+++ b/x/delayedack/keeper/fraud.go
@@ -21,7 +21,7 @@ func (k Keeper) OnHardFork(ctx sdk.Context, rollappID string, lastValidHeight ui
 
 	// Iterate over all the pending packets and revert them
 	for _, rollappPacket := range rollappPendingPackets {
-		logContext := []interface{}{
+		logContext := []any{
 			"rollappID", rollappID,
 			"sourceChannel", rollappPacket.Packet.SourceChannel,
 			"destChannel", rollappPacket.Packet.DestinationChannel,

--- a/x/dymns/types/params.go
+++ b/x/dymns/types/params.go
@@ -200,7 +200,7 @@ func (m MiscParams) Validate() error {
 }
 
 // validateEpochIdentifier checks if the given epoch identifier is valid.
-func validateEpochIdentifier(i interface{}) error {
+func validateEpochIdentifier(i any) error {
 	v, ok := i.(string)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
@@ -217,7 +217,7 @@ func validateEpochIdentifier(i interface{}) error {
 }
 
 // validatePriceParams checks if the given PriceParams are valid.
-func validatePriceParams(i interface{}) error {
+func validatePriceParams(i any) error {
 	m, ok := i.(PriceParams)
 	if !ok {
 		return errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid parameter type: %T", i)
@@ -330,7 +330,7 @@ func validateAliasPriceParams(m PriceParams) error {
 }
 
 // validateChainsParams checks if the given ChainsParams are valid.
-func validateChainsParams(i interface{}) error {
+func validateChainsParams(i any) error {
 	m, ok := i.(ChainsParams)
 	if !ok {
 		return errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid parameter type: %T", i)
@@ -384,7 +384,7 @@ func validateAliasesOfChainIds(aliasesOfChainIds []AliasesOfChainId) error {
 }
 
 // validateMiscParams checks if the given MiscParams are valid.
-func validateMiscParams(i interface{}) error {
+func validateMiscParams(i any) error {
 	m, ok := i.(MiscParams)
 	if !ok {
 		return errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid parameter type: %T", i)

--- a/x/dymns/types/params_test.go
+++ b/x/dymns/types/params_test.go
@@ -534,7 +534,7 @@ func TestMiscParams_Validate(t *testing.T) {
 func Test_validateEpochIdentifier(t *testing.T) {
 	tests := []struct {
 		name    string
-		i       interface{}
+		i       any
 		wantErr bool
 	}{
 		{

--- a/x/ibc_completion/ibc_module.go
+++ b/x/ibc_completion/ibc_module.go
@@ -211,7 +211,7 @@ func parseEIBCMemo(memoBz []byte) (commontypes.CompletionHookCall, error) {
 }
 
 func memoHasConflictingMiddleware(memoBz []byte) bool {
-	d := make(map[string]interface{})
+	d := make(map[string]any)
 	err := json.Unmarshal(memoBz, &d)
 	containsCosmosPacketForwardMemo := d[pfmKey] != nil
 	return err != nil || containsCosmosPacketForwardMemo


### PR DESCRIPTION
## Description

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.

----

Closes #XXX

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x]  Targeted PR against the correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

----

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
