### PR TITLE
CI: migrate workflows to checkout v6

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout the repository
-          uses: actions/checkout@v5
+          uses: actions/checkout@v6
           with:
             fetch-depth: 0
         

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - uses: actions/setup-go@v3
         with:
           go-version: "1.22"

--- a/.github/workflows/e2e-test-nightly.yml
+++ b/.github/workflows/e2e-test-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/e2e_test_upgrade.yml
+++ b/.github/workflows/e2e_test_upgrade.yml
@@ -14,7 +14,7 @@ jobs:
       UPGRADE_NAME: ${{ steps.set-output.outputs.upgrade }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set environment variable
         id: set-output

--- a/.github/workflows/golangci_lint.yml
+++ b/.github/workflows/golangci_lint.yml
@@ -12,7 +12,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"

--- a/.github/workflows/label-internal-pr.yml
+++ b/.github/workflows/label-internal-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get Pull Request Author and Check Membership
         id: pr

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -11,7 +11,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v3.2.0
         with:

--- a/.github/workflows/proto.yaml
+++ b/.github/workflows/proto.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v2
@@ -52,7 +52,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: bufbuild/buf-setup-action@v1.50.0
       - uses: bufbuild/buf-breaking-action@v1.1.4
         with:

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Free disk space
         run: curl -fsSL https://raw.githubusercontent.com/apache/arrow/2c63d481dcf7582d7b8ab3664ff4bdf45d7dd599/ci/scripts/util_free_space.sh | bash
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/release_docker_images.yml
+++ b/.github/workflows/release_docker_images.yml
@@ -25,7 +25,7 @@ jobs:
       steps:
         - 
           name: Check out the repo
-          uses: actions/checkout@v5
+          uses: actions/checkout@v6
         -
           name: Set up QEMU
           uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       GOPROXY: https://proxy.golang.org
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/update_docker_images.yml
+++ b/.github/workflows/update_docker_images.yml
@@ -19,7 +19,7 @@ jobs:
       steps:
         - 
           name: Check out the repo
-          uses: actions/checkout@v5
+          uses: actions/checkout@v6
         -
           name: Set up QEMU
           uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Migrate workflows to checkout@v6 (Node 24 runtime). Min runner: v2.329.0.

https://github.com/actions/checkout/releases/tag/v6.0.0