### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/app/apptesting/events.go
+++ b/app/apptesting/events.go
@@ -36,9 +36,9 @@ func (s *KeeperTestHelper) FindEvent(events []sdk.Event, name string) sdk.Event 
 
 // FindLastEventOfType returns the last event of the given type.
 func (s *KeeperTestHelper) FindLastEventOfType(events []sdk.Event, eventType string) (sdk.Event, bool) {
-	for i := len(events) - 1; i >= 0; i-- {
-		if events[i].Type == eventType {
-			return events[i], true
+	for _, v := range slices.Backward(events) {
+		if v.Type == eventType {
+			return v, true
 		}
 	}
 	return sdk.Event{}, false

--- a/x/rollapp/types/rollapp.go
+++ b/x/rollapp/types/rollapp.go
@@ -142,9 +142,9 @@ func (r Rollapp) LatestRevision() Revision {
 
 // TODO: rollapp type method should be more robust https://github.com/dymensionxyz/dymension/issues/1596
 func (r Rollapp) GetRevisionForHeight(h uint64) Revision {
-	for i := len(r.Revisions) - 1; i >= 0; i-- {
-		if r.Revisions[i].StartHeight <= h {
-			return r.Revisions[i]
+	for _, v := range slices.Backward(r.Revisions) {
+		if v.StartHeight <= h {
+			return v
 		}
 	}
 	return Revision{}


### PR DESCRIPTION
## Description

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899


----

Closes #XXX

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x]  Targeted PR against the correct branch
- [x]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [x]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

----

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
