### PR TITLE
fix(eibc): honor agent policy revocation

### DIFF
--- a/x/agent/doc.go
+++ b/x/agent/doc.go
@@ -2,6 +2,7 @@
 // Agents register with an attestation policy, may rotate it after a timelock,
 // and append actions verified against the policy currently in force. A
 // governance-gated denylist prevents byte-identical policy fingerprints from
-// registering new agents or appending attested actions. Unrevoking is fully
-// reversible since agent state is never mutated by revocation.
+// registering new agents, appending attested actions, or fulfilling eIBC orders
+// through agent-bound on-demand LPs. Unrevoking is fully reversible since agent
+// state is never mutated by revocation.
 package agent

--- a/x/agent/keeper/revoke.go
+++ b/x/agent/keeper/revoke.go
@@ -41,14 +41,14 @@ func (k Keeper) IsPolicyRevoked(ctx sdk.Context, fp string) (bool, error) {
 	return k.revokedPolicies.Has(ctx, fp)
 }
 
-// IsAgentLive reports whether an agent may act on-chain. Keep this check on
-// agent.Policy aligned with SubmitAttestedAction's revocation check.
+// IsAgentLive reports whether an agent may act on-chain. Keep this effective
+// policy check aligned with SubmitAttestedAction and the Agent query.
 func (k Keeper) IsAgentLive(ctx sdk.Context, agentID string) bool {
 	agent, err := k.agents.Get(ctx, agentID)
 	if err != nil || !agent.Active {
 		return false
 	}
-	fp, err := types.PolicyFingerprint(agent.Policy)
+	fp, err := types.PolicyFingerprint(agent.EffectivePolicy(ctx.BlockHeight()))
 	if err != nil {
 		return false
 	}

--- a/x/agent/keeper/revoke.go
+++ b/x/agent/keeper/revoke.go
@@ -41,6 +41,24 @@ func (k Keeper) IsPolicyRevoked(ctx sdk.Context, fp string) (bool, error) {
 	return k.revokedPolicies.Has(ctx, fp)
 }
 
+// IsAgentLive reports whether an agent may act on-chain. Keep this check on
+// agent.Policy aligned with SubmitAttestedAction's revocation check.
+func (k Keeper) IsAgentLive(ctx sdk.Context, agentID string) bool {
+	agent, err := k.agents.Get(ctx, agentID)
+	if err != nil || !agent.Active {
+		return false
+	}
+	fp, err := types.PolicyFingerprint(agent.Policy)
+	if err != nil {
+		return false
+	}
+	revoked, err := k.IsPolicyRevoked(ctx, fp)
+	if err != nil {
+		return false
+	}
+	return !revoked
+}
+
 // AllRevokedPolicies returns all revoked fingerprints in ascending order.
 func (k Keeper) AllRevokedPolicies(ctx sdk.Context) ([]string, error) {
 	var fps []string

--- a/x/agent/keeper/revoke_test.go
+++ b/x/agent/keeper/revoke_test.go
@@ -92,6 +92,32 @@ func TestRevokePolicy_AuthorityGated(t *testing.T) {
 	require.False(t, revoked)
 }
 
+func TestIsAgentLive(t *testing.T) {
+	ctx, k, _ := setup(t)
+	ms := keeper.NewMsgServerImpl(*k)
+
+	require.False(t, k.IsAgentLive(ctx, "unknown"))
+
+	require.NoError(t, k.SetAgent(ctx, types.Agent{
+		Id:     "inactive",
+		Policy: policyA(),
+		Active: false,
+	}))
+	require.False(t, k.IsAgentLive(ctx, "inactive"))
+
+	seedAgentWithPolicy(t, ctx, k, "active", policyA())
+	require.True(t, k.IsAgentLive(ctx, "active"))
+
+	fp := fingerprint(t, policyA())
+	_, err := ms.RevokePolicy(ctx, types.NewMsgRevokePolicy(govAuthority, fp, "bad image"))
+	require.NoError(t, err)
+	require.False(t, k.IsAgentLive(ctx, "active"))
+
+	_, err = ms.UnrevokePolicy(ctx, types.NewMsgUnrevokePolicy(govAuthority, fp))
+	require.NoError(t, err)
+	require.True(t, k.IsAgentLive(ctx, "active"))
+}
+
 func TestRevokePolicy_ValidateBasic(t *testing.T) {
 	ctx, k, _ := setup(t)
 	ms := keeper.NewMsgServerImpl(*k)

--- a/x/agent/keeper/revoke_test.go
+++ b/x/agent/keeper/revoke_test.go
@@ -118,6 +118,37 @@ func TestIsAgentLive(t *testing.T) {
 	require.True(t, k.IsAgentLive(ctx, "active"))
 }
 
+func TestIsAgentLive_UsesEffectivePolicy(t *testing.T) {
+	ctx, k, _ := setup(t)
+	ms := keeper.NewMsgServerImpl(*k)
+	fpA := fingerprint(t, policyA())
+	fpB := fingerprint(t, policyB())
+
+	_, err := ms.RevokePolicy(ctx, types.NewMsgRevokePolicy(govAuthority, fpB, "bad rotation"))
+	require.NoError(t, err)
+	seedAgentWithPolicy(t, ctx, k, "rotating-to-revoked", policyA())
+	agent, _ := k.GetAgent(ctx, "rotating-to-revoked")
+	pending := policyB()
+	agent.PendingPolicy = &pending
+	agent.PendingPolicyHeight = 100
+	require.NoError(t, k.SetAgent(ctx, agent))
+	require.True(t, k.IsAgentLive(ctx.WithBlockHeight(99), agent.Id))
+	require.False(t, k.IsAgentLive(ctx.WithBlockHeight(100), agent.Id))
+
+	_, err = ms.RevokePolicy(ctx, types.NewMsgRevokePolicy(govAuthority, fpA, "bad old policy"))
+	require.NoError(t, err)
+	_, err = ms.UnrevokePolicy(ctx, types.NewMsgUnrevokePolicy(govAuthority, fpB))
+	require.NoError(t, err)
+	seedAgentWithPolicy(t, ctx, k, "rotating-from-revoked", policyA())
+	agent, _ = k.GetAgent(ctx, "rotating-from-revoked")
+	pending = policyB()
+	agent.PendingPolicy = &pending
+	agent.PendingPolicyHeight = 100
+	require.NoError(t, k.SetAgent(ctx, agent))
+	require.False(t, k.IsAgentLive(ctx.WithBlockHeight(99), agent.Id))
+	require.True(t, k.IsAgentLive(ctx.WithBlockHeight(100), agent.Id))
+}
+
 func TestRevokePolicy_ValidateBasic(t *testing.T) {
 	ctx, k, _ := setup(t)
 	ms := keeper.NewMsgServerImpl(*k)

--- a/x/agent/types/proto_layout_test.go
+++ b/x/agent/types/proto_layout_test.go
@@ -37,6 +37,8 @@ func TestAgentProtoFieldCompatibility(t *testing.T) {
 			"MaxActionBytes":            {"varint,1,opt,name=max_action_bytes,json=maxActionBytes,proto3", reflect.TypeOf(uint64(0))},
 			"AgentRegistrationFee":      {"bytes,2,opt,name=agent_registration_fee,json=agentRegistrationFee,proto3", reflect.TypeOf(types.DefaultParams().AgentRegistrationFee)},
 			"PolicyRotationDelayBlocks": {"varint,3,opt,name=policy_rotation_delay_blocks,json=policyRotationDelayBlocks,proto3", reflect.TypeOf(uint64(0))},
+			"FeedbackFee":               {"bytes,4,opt,name=feedback_fee,json=feedbackFee,proto3", reflect.TypeOf(types.DefaultParams().FeedbackFee)},
+			"FeedbackTagMaxBytes":       {"varint,5,opt,name=feedback_tag_max_bytes,json=feedbackTagMaxBytes,proto3", reflect.TypeOf(uint64(0))},
 		}},
 		{types.ActionLogEntry{}, map[string]fieldContract{
 			"AgentId":     {"bytes,1,opt,name=agent_id,json=agentId,proto3", reflect.TypeOf("")},
@@ -47,8 +49,9 @@ func TestAgentProtoFieldCompatibility(t *testing.T) {
 			"Time":        {"bytes,6,opt,name=time,proto3,stdtime", reflect.TypeOf(time.Time{})},
 		}},
 		{types.EventRegisterAgent{}, map[string]fieldContract{
-			"AgentId": {"bytes,1,opt,name=agent_id,json=agentId,proto3", reflect.TypeOf("")},
-			"Owner":   {"bytes,2,opt,name=owner,proto3", reflect.TypeOf("")},
+			"AgentId":     {"bytes,1,opt,name=agent_id,json=agentId,proto3", reflect.TypeOf("")},
+			"Owner":       {"bytes,2,opt,name=owner,proto3", reflect.TypeOf("")},
+			"Fingerprint": {"bytes,3,opt,name=fingerprint,proto3", reflect.TypeOf("")},
 		}},
 		{types.EventDeactivateAgent{}, map[string]fieldContract{
 			"AgentId": {"bytes,1,opt,name=agent_id,json=agentId,proto3", reflect.TypeOf("")},
@@ -91,14 +94,17 @@ func TestAgentProtoRoundTripCompatibility(t *testing.T) {
 		}, &types.Agent{}},
 		{&types.Params{
 			MaxActionBytes: 1024, AgentRegistrationFee: sdk.NewInt64Coin("adym", 12),
-			PolicyRotationDelayBlocks: 99,
+			PolicyRotationDelayBlocks: 99, FeedbackFee: sdk.NewInt64Coin("adym", 34),
+			FeedbackTagMaxBytes: 56,
 		}, &types.Params{}},
 		{&types.ActionLogEntry{
 			AgentId: "agent-1", Seq: 7, Payload: []byte("payload"),
 			PayloadHash: []byte("hash"), Height: 42,
 			Time: time.Date(2026, time.July, 14, 12, 34, 56, 789, time.UTC),
 		}, &types.ActionLogEntry{}},
-		{&types.EventRegisterAgent{AgentId: "agent-1", Owner: "dym1owner"}, &types.EventRegisterAgent{}},
+		{&types.EventRegisterAgent{
+			AgentId: "agent-1", Owner: "dym1owner", Fingerprint: "fingerprint",
+		}, &types.EventRegisterAgent{}},
 		{&types.EventDeactivateAgent{AgentId: "agent-1", Owner: "dym1owner"}, &types.EventDeactivateAgent{}},
 		{&types.EventUpdateAgentPolicy{AgentId: "agent-1", ActivationHeight: 42}, &types.EventUpdateAgentPolicy{}},
 	}

--- a/x/eibc/keeper/lp_test.go
+++ b/x/eibc/keeper/lp_test.go
@@ -378,6 +378,30 @@ func (suite *KeeperTestSuite) TestLPAgentPolicyRevocation() {
 	suite.Require().NoError(err)
 	suite.Require().Len(compat, 1)
 	suite.Require().NoError(k.FulfillByOnDemandLP(suite.Ctx, id2, 0))
+
+	agent, found := suite.App.AgentKeeper.GetAgent(suite.Ctx, "agent1")
+	suite.Require().True(found)
+	revokedPendingPolicy := policy
+	revokedPendingPolicy.PolicyValues = `{"measurement":"revoked-rotation"}`
+	agent.PendingPolicy = &revokedPendingPolicy
+	agent.PendingPolicyHeight = suite.Ctx.BlockHeight() + 1
+	suite.Require().NoError(suite.App.AgentKeeper.SetAgent(suite.Ctx, agent))
+	pendingFP, err := agenttypes.PolicyFingerprint(revokedPendingPolicy)
+	suite.Require().NoError(err)
+	_, err = agentMsgServer.RevokePolicy(suite.Ctx, agenttypes.NewMsgRevokePolicy(
+		govAuthority, pendingFP, "bad rotation",
+	))
+	suite.Require().NoError(err)
+
+	suite.Ctx = suite.Ctx.WithBlockHeight(agent.PendingPolicyHeight)
+	id3 := suite.orderWithSeq(3, orderAddr.String(), math.NewInt(40), math.NewInt(10))
+	order, err = k.GetDemandOrder(suite.Ctx, commontypes.Status_PENDING, id3)
+	suite.Require().NoError(err)
+	compat, err = k.LPs.GetOrderCompatibleLPs(suite.Ctx, *order)
+	suite.Require().NoError(err)
+	suite.Require().Empty(compat)
+	err = k.FulfillByOnDemandLP(suite.Ctx, id3, 0)
+	suite.Require().True(errorsmod.IsOf(err, gerrc.ErrNotFound), "expected no compatible lp, got %v", err)
 }
 
 // CreateOnDemandLP requires a referenced agent to exist, but not to be active.

--- a/x/eibc/keeper/lp_test.go
+++ b/x/eibc/keeper/lp_test.go
@@ -4,9 +4,12 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dymensionxyz/dymension/v3/app/apptesting"
 	agentkeeper "github.com/dymensionxyz/dymension/v3/x/agent/keeper"
 	agenttypes "github.com/dymensionxyz/dymension/v3/x/agent/types"
+	"github.com/dymensionxyz/dymension/v3/x/common/tee"
 	commontypes "github.com/dymensionxyz/dymension/v3/x/common/types"
 	"github.com/dymensionxyz/dymension/v3/x/eibc/types"
 	"github.com/dymensionxyz/gerr-cosmos/gerrc"
@@ -314,6 +317,66 @@ func (suite *KeeperTestSuite) TestLPAgentBinding() {
 	suite.Require().Len(compat, 1)
 	suite.Require().Equal(unboundID, compat[0].Id)
 	suite.Require().NotEqual(boundID, compat[0].Id)
+	suite.Require().NoError(k.FulfillByOnDemandLP(suite.Ctx, id2, 0))
+}
+
+func (suite *KeeperTestSuite) TestLPAgentPolicyRevocation() {
+	k := suite.App.EIBCKeeper
+	addrs := apptesting.AddTestAddrs(suite.App, suite.Ctx, 2, math.NewInt(10_000_000))
+	orderAddr, lpAddr := addrs[0], addrs[1]
+	policy := tee.Policy{
+		GcpRootCertPem:  "cert",
+		PolicyValues:    `{"measurement":"agent-lp"}`,
+		PolicyQuery:     "data.x.allow",
+		PolicyStructure: "package x\nallow = true",
+	}
+	registrationFee, err := suite.App.AgentKeeper.AgentRegistrationFee(suite.Ctx)
+	suite.Require().NoError(err)
+	suite.FundAcc(lpAddr, sdk.NewCoins(registrationFee))
+	agentMsgServer := agentkeeper.NewMsgServerImpl(*suite.App.AgentKeeper)
+	_, err = agentMsgServer.RegisterAgent(
+		suite.Ctx,
+		agenttypes.NewMsgRegisterAgent(lpAddr.String(), "agent1", policy),
+	)
+	suite.Require().NoError(err)
+	_, err = k.LPs.Create(suite.Ctx, &types.OnDemandLP{
+		FundsAddr:  lpAddr.String(),
+		Rollapp:    rollappPacket.RollappId,
+		Denom:      sdk.DefaultBondDenom,
+		MaxPrice:   math.NewInt(100),
+		MinFee:     math.LegacyZeroDec(),
+		SpendLimit: math.NewInt(1000),
+		AgentId:    "agent1",
+	})
+	suite.Require().NoError(err)
+
+	id1 := suite.orderWithSeq(1, orderAddr.String(), math.NewInt(40), math.NewInt(10))
+	suite.Require().NoError(k.FulfillByOnDemandLP(suite.Ctx, id1, 0))
+
+	fp, err := agenttypes.PolicyFingerprint(policy)
+	suite.Require().NoError(err)
+	govAuthority := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+	_, err = agentMsgServer.RevokePolicy(suite.Ctx, agenttypes.NewMsgRevokePolicy(
+		govAuthority, fp, "bad image",
+	))
+	suite.Require().NoError(err)
+
+	id2 := suite.orderWithSeq(2, orderAddr.String(), math.NewInt(40), math.NewInt(10))
+	order, err := k.GetDemandOrder(suite.Ctx, commontypes.Status_PENDING, id2)
+	suite.Require().NoError(err)
+	compat, err := k.LPs.GetOrderCompatibleLPs(suite.Ctx, *order)
+	suite.Require().NoError(err)
+	suite.Require().Empty(compat)
+	err = k.FulfillByOnDemandLP(suite.Ctx, id2, 0)
+	suite.Require().True(errorsmod.IsOf(err, gerrc.ErrNotFound), "expected no compatible lp, got %v", err)
+
+	_, err = agentMsgServer.UnrevokePolicy(suite.Ctx, agenttypes.NewMsgUnrevokePolicy(
+		govAuthority, fp,
+	))
+	suite.Require().NoError(err)
+	compat, err = k.LPs.GetOrderCompatibleLPs(suite.Ctx, *order)
+	suite.Require().NoError(err)
+	suite.Require().Len(compat, 1)
 	suite.Require().NoError(k.FulfillByOnDemandLP(suite.Ctx, id2, 0))
 }
 

--- a/x/eibc/keeper/lps.go
+++ b/x/eibc/keeper/lps.go
@@ -199,14 +199,12 @@ func (s LPs) GetOrderCompatibleLPs(ctx sdk.Context, o types.DemandOrder) ([]type
 }
 
 // agentLive reports whether an LP bound to agentID may fulfill. Unbound LPs
-// (empty id) are always live; bound LPs require the agent to exist and be
-// active, so deactivating an agent lazily disables its whole LP fleet.
+// (empty id) are always live.
 func (s LPs) agentLive(ctx sdk.Context, agentID string) bool {
 	if agentID == "" {
 		return true
 	}
-	agent, found := s.agents.GetAgent(ctx, agentID)
-	return found && agent.Active
+	return s.agents.IsAgentLive(ctx, agentID)
 }
 
 // NextID returns the current value of the LP id sequence.

--- a/x/eibc/types/expected_keepers.go
+++ b/x/eibc/types/expected_keepers.go
@@ -37,4 +37,5 @@ type RollappKeeper interface {
 // AgentKeeper provides liveness checks for LPs bound to an x/agent agent.
 type AgentKeeper interface {
 	GetAgent(ctx sdk.Context, id string) (agenttypes.Agent, bool)
+	IsAgentLive(ctx sdk.Context, id string) bool
 }


### PR DESCRIPTION
## Summary

- add the x/agent-owned `IsAgentLive` predicate for existence, activation, and effective-policy revocation
- resolve matured pending rotations at the current block height, matching attested-action and query semantics
- fail closed on agent, fingerprint, or revocation-store read errors
- delegate agent-bound eIBC LP matching to the full operational predicate while preserving unbound LP behavior
- cover revoke/unrevoke and both policy-rotation directions through keeper and eIBC fulfillment tests
- document the eIBC effect of policy revocation
- synchronize protobuf compatibility contracts with the checked-in agent schema

Closes #2192

## Proof of execution

### Agent liveness follows revocation, unrevocation, and effective-policy rotation
**How:** `go test ./x/agent/keeper -run 'TestIsAgentLive' -count=1 -v`
**Evidence:**
```text
=== RUN   TestIsAgentLive
--- PASS: TestIsAgentLive (0.00s)
=== RUN   TestIsAgentLive_UsesEffectivePolicy
--- PASS: TestIsAgentLive_UsesEffectivePolicy (0.00s)
PASS
ok  	github.com/dymensionxyz/dymension/v3/x/agent/keeper	0.122s
```

### Revoked agent-bound LPs, including matured revoked rotations, cannot fulfill
**How:** `go test ./x/eibc/keeper -run '^TestKeeperTestSuite/TestLPAgentPolicyRevocation$' -count=1 -v`
**Evidence:**
```text
=== RUN   TestKeeperTestSuite
=== RUN   TestKeeperTestSuite/TestLPAgentPolicyRevocation
--- PASS: TestKeeperTestSuite (0.11s)
    --- PASS: TestKeeperTestSuite/TestLPAgentPolicyRevocation (0.11s)
PASS
ok  	github.com/dymensionxyz/dymension/v3/x/eibc/keeper	0.244s
```

### Protobuf compatibility contracts cover every generated field
**How:** `go test ./x/agent/types -run 'TestAgentProto(Field|RoundTrip)Compatibility' -count=1 -v`
**Evidence:**
```text
--- PASS: TestAgentProtoFieldCompatibility (0.00s)
    --- PASS: TestAgentProtoFieldCompatibility/Params (0.00s)
    --- PASS: TestAgentProtoFieldCompatibility/EventRegisterAgent (0.00s)
--- PASS: TestAgentProtoRoundTripCompatibility (0.00s)
    --- PASS: TestAgentProtoRoundTripCompatibility/Params (0.00s)
    --- PASS: TestAgentProtoRoundTripCompatibility/EventRegisterAgent (0.00s)
PASS
ok  	github.com/dymensionxyz/dymension/v3/x/agent/types	0.082s
```

### Exact CI race-and-coverage command passes
**How:** `go-acc -o coverage.txt ./... -- -v --race`
**Evidence:**
```text
PASS
coverage: 8.4
ok  	github.com/dymensionxyz/dymension/v3/x/streamer/keeper	28.555s	coverage: 8.4
PASS
coverage: 0.7
ok  	github.com/dymensionxyz/dymension/v3/x/streamer/types	1.690s	coverage: 0.7
PASS
coverage: 3.5
ok  	github.com/dymensionxyz/dymension/v3/x/vfc/hooks	2.725s	coverage: 3.5
```

### Changed Go code passes lint and formatting checks
**How:** `golangci-lint run --new-from-rev=HEAD ./x/agent/... ./x/eibc/...` and `git diff --check`
**Evidence:**
```text
0 issues.
```

**Not verified:** nothing; all behaviors above are proven.
