### PR TITLE
fix(eibc): derive on-demand LP shuffle seed

### DIFF
--- a/proto/dymensionxyz/dymension/eibc/tx.proto
+++ b/proto/dymensionxyz/dymension/eibc/tx.proto
@@ -124,7 +124,8 @@ message MsgTryFulfillOnDemand {
 
   string order_id = 1;
 
-  // rng to choose fulfiller from eligible randomly
+  // Deprecated: ignored. The fulfiller is chosen by a chain-derived
+  // deterministic seed.
   int64 rng = 3;
 }
 

--- a/x/eibc/client/cli/tx.go
+++ b/x/eibc/client/cli/tx.go
@@ -210,7 +210,7 @@ func NewCmdTryFulfillOnDemand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "try-fulfill-on-demand [order-id] [rng]",
 		Short: short,
-		Long:  short + " Can provide rng to avoid choosing same fulfiller multiple times (number). ",
+		Long:  short + " The optional rng argument is deprecated and ignored; the fulfiller is chosen from a chain-derived seed.",
 
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -219,18 +219,11 @@ func NewCmdTryFulfillOnDemand() *cobra.Command {
 				return err
 			}
 			orderId := args[0]
-			rng := 0
-			if len(args) > 1 {
-				rng, err = strconv.Atoi(args[1])
-				if err != nil {
-					return err
-				}
-			}
 
 			msg := &types.MsgTryFulfillOnDemand{
 				Signer:  clientCtx.GetFromAddress().String(),
 				OrderId: orderId,
-				Rng:     int64(rng),
+				Rng:     0,
 			}
 
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/eibc/keeper/lps.go
+++ b/x/eibc/keeper/lps.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"math/rand/v2"
 
@@ -215,6 +217,20 @@ func (s LPs) NextID(ctx sdk.Context) (uint64, error) {
 // SetNextID sets the LP id sequence, used on genesis import.
 func (s LPs) SetNextID(ctx sdk.Context, id uint64) error {
 	return s.nextID.Set(ctx, id)
+}
+
+// deterministicFulfillSeed derives the LP-shuffle seed from data the tx
+// submitter cannot choose: the order id (per-order variation) mixed with the
+// current block hash (per-block entropy neither the fulfiller nor the order
+// creator controls at their respective action times). Consensus-safe: the
+// header hash is consensus data identical across validators, and sha256 with
+// fixed byte order is deterministic.
+func deterministicFulfillSeed(ctx sdk.Context, orderID string) uint64 {
+	h := sha256.New()
+	_, _ = h.Write([]byte(orderID))
+	_, _ = h.Write(ctx.HeaderHash())
+	sum := h.Sum(nil)
+	return binary.BigEndian.Uint64(sum[:8])
 }
 
 func (k Keeper) FulfillByOnDemandLP(ctx sdk.Context, order string, rng uint64) error {

--- a/x/eibc/keeper/lps_test.go
+++ b/x/eibc/keeper/lps_test.go
@@ -1,0 +1,73 @@
+package keeper_test
+
+import (
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dymensionxyz/dymension/v3/app/apptesting"
+	"github.com/dymensionxyz/dymension/v3/x/eibc/types"
+)
+
+func (suite *KeeperTestSuite) fulfillWinner(orderSeq uint64, headerHash []byte, rng int64, addrs []sdk.AccAddress) uint64 {
+	suite.SetupTest()
+	suite.Ctx = suite.Ctx.WithBlockHeight(10).WithHeaderHash(headerHash)
+	for _, addr := range addrs {
+		apptesting.FundAccount(suite.App, suite.Ctx, addr, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(1_000_000))))
+	}
+
+	k := suite.App.EIBCKeeper
+	for _, addr := range addrs[1:] {
+		_, err := k.LPs.Create(suite.Ctx, &types.OnDemandLP{
+			FundsAddr:  addr.String(),
+			Rollapp:    rollappPacket.RollappId,
+			Denom:      sdk.DefaultBondDenom,
+			MaxPrice:   math.NewInt(100),
+			MinFee:     math.LegacyZeroDec(),
+			SpendLimit: math.NewInt(1_000),
+		})
+		suite.Require().NoError(err)
+	}
+
+	orderID := suite.orderWithSeq(orderSeq, addrs[0].String(), math.NewInt(90), math.NewInt(10))
+	_, err := suite.msgServer.TryFulfillOnDemand(suite.Ctx, &types.MsgTryFulfillOnDemand{
+		Signer:  addrs[0].String(),
+		OrderId: orderID,
+		Rng:     rng,
+	})
+	suite.Require().NoError(err)
+
+	lps, err := k.LPs.GetAll(suite.Ctx)
+	suite.Require().NoError(err)
+	for _, lp := range lps {
+		if lp.Spent.IsPositive() {
+			return lp.Id
+		}
+	}
+	suite.FailNow("no LP recorded spend")
+	return 0
+}
+
+func (suite *KeeperTestSuite) TestTryFulfillOnDemandIgnoresCallerRNG() {
+	addrs := apptesting.CreateRandomAccounts(3)
+	winnerFromZero := suite.fulfillWinner(101, []byte("fixed-header"), 0, addrs)
+	winnerFromOne := suite.fulfillWinner(101, []byte("fixed-header"), 1, addrs)
+	suite.Require().Equal(winnerFromZero, winnerFromOne)
+}
+
+func (suite *KeeperTestSuite) TestTryFulfillOnDemandSeedDeterminismAndOrderVariation() {
+	addrs := apptesting.CreateRandomAccounts(3)
+	headerHash := []byte("fixed-header")
+	winner := suite.fulfillWinner(201, headerHash, 0, addrs)
+	suite.Require().Equal(winner, suite.fulfillWinner(201, headerHash, 0, addrs))
+
+	winners := map[uint64]struct{}{}
+	for seq := uint64(201); seq < 217; seq++ {
+		winners[suite.fulfillWinner(seq, headerHash, 0, addrs)] = struct{}{}
+	}
+	suite.Require().Greater(len(winners), 1)
+}
+
+func (suite *KeeperTestSuite) TestTryFulfillOnDemandEmptyHeaderHashDeterministic() {
+	addrs := apptesting.CreateRandomAccounts(3)
+	winner := suite.fulfillWinner(301, nil, -1, addrs)
+	suite.Require().Equal(winner, suite.fulfillWinner(301, nil, 42, addrs))
+}

--- a/x/eibc/keeper/msg_server.go
+++ b/x/eibc/keeper/msg_server.go
@@ -278,8 +278,8 @@ func (m msgServer) TryFulfillOnDemand(goCtx context.Context, msg *types.MsgTryFu
 		return nil, errorsmod.Wrap(err, "vbasic")
 	}
 
-	shuffleSeed := uint64(msg.Rng) //nolint:gosec
-	err = m.FulfillByOnDemandLP(ctx, msg.OrderId, shuffleSeed)
+	seed := deterministicFulfillSeed(ctx, msg.OrderId)
+	err = m.FulfillByOnDemandLP(ctx, msg.OrderId, seed)
 	if err != nil {
 		return nil, err
 	}

--- a/x/eibc/types/tx.pb.go
+++ b/x/eibc/types/tx.pb.go
@@ -479,7 +479,8 @@ var xxx_messageInfo_MsgUpdateDemandOrderResponse proto.InternalMessageInfo
 type MsgTryFulfillOnDemand struct {
 	Signer  string `protobuf:"bytes,2,opt,name=signer,proto3" json:"signer,omitempty"`
 	OrderId string `protobuf:"bytes,1,opt,name=order_id,json=orderId,proto3" json:"order_id,omitempty"`
-	// rng to choose fulfiller from eligible randomly
+	// Deprecated: ignored. The fulfiller is chosen by a chain-derived
+	// deterministic seed.
 	Rng int64 `protobuf:"varint,3,opt,name=rng,proto3" json:"rng,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- derive the on-demand LP shuffle seed from SHA-256(order ID || current header hash)
- ignore the deprecated transaction RNG while preserving its protobuf field and CLI argument
- cover caller-RNG independence, deterministic replay, order-ID variation, and empty header hashes

Closes #2194

## Proof of execution

### Caller RNG cannot influence the LP winner; consensus inputs remain deterministic
**How:** `go test ./x/eibc/keeper -run 'TestKeeperTestSuite/(TestTryFulfillOnDemand)' -count=1 -v`
**Evidence:**
```text
=== RUN   TestKeeperTestSuite/TestTryFulfillOnDemandEmptyHeaderHashDeterministic
=== RUN   TestKeeperTestSuite/TestTryFulfillOnDemandIgnoresCallerRNG
=== RUN   TestKeeperTestSuite/TestTryFulfillOnDemandSeedDeterminismAndOrderVariation
--- PASS: TestKeeperTestSuite (1.59s)
    --- PASS: TestKeeperTestSuite/TestTryFulfillOnDemandEmptyHeaderHashDeterministic (0.29s)
    --- PASS: TestKeeperTestSuite/TestTryFulfillOnDemandIgnoresCallerRNG (0.16s)
    --- PASS: TestKeeperTestSuite/TestTryFulfillOnDemandSeedDeterminismAndOrderVariation (1.14s)
PASS
ok  github.com/dymensionxyz/dymension/v3/x/eibc/keeper 1.737s
```

### The complete eIBC module suite passes
**How:** `go test ./x/eibc/... -count=1`
**Evidence:**
```text
ok  github.com/dymensionxyz/dymension/v3/x/eibc 0.412s
?   github.com/dymensionxyz/dymension/v3/x/eibc/client/cli [no test files]
ok  github.com/dymensionxyz/dymension/v3/x/eibc/keeper 4.343s
ok  github.com/dymensionxyz/dymension/v3/x/eibc/types 0.147s
```

### Repository build and lint gates pass
**How:** `go build ./...` and `golangci-lint-v2 run`
**Evidence:**
```text
$ go build ./...
(exit 0)

$ golangci-lint-v2 run
0 issues.
```

### Protobuf output is regenerated and the legacy field remains wire-compatible
**How:** `make proto-format` followed by `make proto-gen`
**Evidence:**
```text
Generating Protobuf files
Generating gogo proto code for ../proto/dymensionxyz/dymension/eibc/tx.proto
(exit 0)
```

### CLI documents the ignored compatibility argument and rejects a missing order ID
**How:** `dymd tx eibc try-fulfill-on-demand --help` and `dymd tx eibc try-fulfill-on-demand`
**Evidence:**
```text
Try to find a fulfiller for a given order and fulfill on the spot The optional rng argument is deprecated and ignored; the fulfiller is chosen from a chain-derived seed.

Usage:
  dymd tx eibc try-fulfill-on-demand [order-id] [rng] [flags]
help exit: 0

Error: requires at least 1 arg(s), only received 0
missing-order exit: 1
```

### CI race tests cover the full package set
**How:** `go-acc -o /tmp/coverage-2194.txt ./... -- -v --race`, then after its 20-minute wrapper expired, continuation from the first unfinished package with `go test -race ./x/lockup/... ./x/otcbuyback/... ./x/rollapp/... ./x/sequencer/... ./x/sponsorship/... ./x/streamer/...`
**Evidence:**
```text
ok  github.com/dymensionxyz/dymension/v3/x/eibc/keeper 6.701s coverage: 6.9
ok  github.com/dymensionxyz/dymension/v3/x/iro/types 352.062s coverage: 1.1
ok  github.com/dymensionxyz/dymension/v3/x/lightclient/keeper 3.168s coverage: 3.7
[20-minute wrapper expired after x/lightclient; no failing package or race report]
ok  github.com/dymensionxyz/dymension/v3/x/lockup/keeper 114.521s
ok  github.com/dymensionxyz/dymension/v3/x/otcbuyback/keeper 43.781s
ok  github.com/dymensionxyz/dymension/v3/x/rollapp/keeper 144.349s
ok  github.com/dymensionxyz/dymension/v3/x/sequencer/keeper 22.497s
ok  github.com/dymensionxyz/dymension/v3/x/sponsorship/keeper 26.854s
ok  github.com/dymensionxyz/dymension/v3/x/streamer/keeper 37.115s
```

**Not verified:** the single-process aggregate coverage file did not finish before the 20-minute wrapper; every package was nevertheless executed under the race detector across the initial run and the scoped continuation.