### PR TITLE
fix(forward): clamp stale IBC timeouts

### DIFF
--- a/x/forward/ibc.go
+++ b/x/forward/ibc.go
@@ -90,6 +90,13 @@ func (h rollToIBCHook) Run(ctx sdk.Context, fundsSource sdk.AccAddress, budget s
 }
 
 func (k Forward) forwardToIBC(ctx sdk.Context, transfer *ibctransfertypes.MsgTransfer, fundsSrc sdk.AccAddress, maxBudget sdk.Coin) error {
+	nowNs := uint64(ctx.BlockTime().UnixNano()) //nolint:gosec // block time is never negative
+	timeoutTimestamp := transfer.TimeoutTimestamp
+	if timeoutTimestamp == 0 || timeoutTimestamp <= nowNs+types.MinForwardIBCTimeout {
+		// Give the final hop a fresh deadline when the composer's absolute timeout is no longer usable.
+		timeoutTimestamp = nowNs + types.DefaultForwardIBCTimeout
+	}
+
 	m := ibctransfertypes.NewMsgTransfer(
 		transfer.SourcePort,
 		transfer.SourceChannel,
@@ -97,7 +104,7 @@ func (k Forward) forwardToIBC(ctx sdk.Context, transfer *ibctransfertypes.MsgTra
 		fundsSrc.String(),
 		transfer.Receiver,
 		ibcclienttypes.Height{}, // ignore, removed in ibc v2 also
-		transfer.TimeoutTimestamp,
+		timeoutTimestamp,
 		transfer.Memo, // include the original memo, so that we can have more functionality down the road (.e.g actions on rollapp)
 	)
 

--- a/x/forward/ibc_test.go
+++ b/x/forward/ibc_test.go
@@ -1,0 +1,76 @@
+package forward
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingTransferKeeper struct {
+	msg *ibctransfertypes.MsgTransfer
+}
+
+func (k *capturingTransferKeeper) Transfer(_ context.Context, msg *ibctransfertypes.MsgTransfer) (*ibctransfertypes.MsgTransferResponse, error) {
+	k.msg = msg
+	return &ibctransfertypes.MsgTransferResponse{}, nil
+}
+
+func TestForwardToIBCClampsTimeoutTimestamp(t *testing.T) {
+	blockTime := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	blockTimeNs := uint64(blockTime.UnixNano())
+	healthyTimeout := uint64(blockTime.Add(2 * time.Hour).UnixNano())
+
+	testCases := []struct {
+		name             string
+		timeoutTimestamp uint64
+		expectedTimeout  uint64
+	}{
+		{
+			name:             "past timeout",
+			timeoutTimestamp: uint64(blockTime.Add(-time.Minute).UnixNano()),
+			expectedTimeout:  uint64(blockTime.Add(time.Hour).UnixNano()),
+		},
+		{
+			name:             "zero timeout",
+			timeoutTimestamp: 0,
+			expectedTimeout:  uint64(blockTime.Add(time.Hour).UnixNano()),
+		},
+		{
+			name:             "healthy timeout",
+			timeoutTimestamp: healthyTimeout,
+			expectedTimeout:  healthyTimeout,
+		},
+		{
+			name:             "minimum lead time boundary",
+			timeoutTimestamp: blockTimeNs + uint64(10*time.Minute),
+			expectedTimeout:  uint64(blockTime.Add(time.Hour).UnixNano()),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			transferKeeper := &capturingTransferKeeper{}
+			forward := New(transferKeeper, nil, nil)
+			transfer := &ibctransfertypes.MsgTransfer{
+				SourcePort:       "transfer",
+				SourceChannel:    "channel-0",
+				Receiver:         "destination",
+				TimeoutTimestamp: tc.timeoutTimestamp,
+				Memo:             "memo",
+			}
+			fundsSource := sdk.AccAddress([]byte("funds-source-address"))
+			budget := sdk.NewCoin("adym", sdkmath.NewInt(10))
+
+			err := forward.forwardToIBC(sdk.Context{}.WithBlockTime(blockTime), transfer, fundsSource, budget)
+
+			require.NoError(t, err)
+			require.NotNil(t, transferKeeper.msg)
+			require.Equal(t, tc.expectedTimeout, transferKeeper.msg.TimeoutTimestamp)
+		})
+	}
+}

--- a/x/forward/types/const.go
+++ b/x/forward/types/const.go
@@ -1,8 +1,19 @@
 package types
 
+import "time"
+
 const (
 	ModuleName = "forward"
 	// not to be confused with ibc apps PFM which uses 'forward' as the fungible packet json memo key
 	HookNameRollToHL  = "dym-fwd-roll-hl"
 	HookNameRollToIBC = "dym-fwd-roll-ibc"
+
+	// DefaultForwardIBCTimeout is the fresh timeout applied to a forwarded IBC
+	// hop when the composer's absolute timeout is missing or already stale at
+	// execution time. Nanoseconds.
+	DefaultForwardIBCTimeout = uint64(time.Hour)
+	// MinForwardIBCTimeout is the minimum remaining lead time a composer-supplied
+	// timeout must have (relative to block time) to be honored as-is; anything
+	// tighter is treated as stale and replaced with DefaultForwardIBCTimeout.
+	MinForwardIBCTimeout = uint64(10 * time.Minute)
 )


### PR DESCRIPTION
Closes #2200

Outbound IBC forwards could inherit an absolute timeout that had already expired while waiting for RollApp completion or Hyperlane delivery, leaving funds at the intermediate recipient. This change deterministically replaces missing, stale, and too-tight deadlines with a fresh one-hour timeout at the shared forwarding choke point while preserving healthy composer deadlines unchanged.

- Clamp stale IBC timeouts once in `forwardToIBC`.
- Cover past, zero, healthy, and inclusive minimum-boundary behavior.
- Keep the result deterministic from consensus block time.

<details><summary>Implementation details</summary>

- Adds `DefaultForwardIBCTimeout` (one hour) and `MinForwardIBCTimeout` (ten minutes) as nanosecond constants.
- Computes `nowNs` exclusively from `ctx.BlockTime()`.
- Replaces `TimeoutTimestamp == 0` or `TimeoutTimestamp <= nowNs + MinForwardIBCTimeout` with `nowNs + DefaultForwardIBCTimeout`.
- Leaves healthy future timestamps untouched and makes no changes to Hyperlane outbound forwarding.

</details>

## Proof of execution

- `TestForwardToIBCClampsTimeoutTimestamp` — PASS for past, zero, healthy two-hour, and exact ten-minute boundary cases via `go test ./x/forward/... -run TestForwardToIBCClampsTimeoutTimestamp -count=1 -v`; CI Build and Test re-runs it.
- Full repository race/coverage suite — PASS via `go-acc -o /tmp/dymension-2200-coverage.txt ./... -- -v --race`; CI Build and Test re-runs this gate.
- Full repository build — PASS via `go build ./...`; CI Build and Test re-runs it.
- Full repository lint — PASS with `0 issues` via `golangci-lint run`; CI golangci-lint re-runs it.

**Not verified:** nothing; all changed backend behavior is covered by committed unit tests and the repository gates above.
