### PR TITLE
feat(dymns): bind agent service records

### DIFF
--- a/app/keepers.go
+++ b/app/keepers.go
@@ -483,12 +483,21 @@ func (a *AppKeepers) InitKeepers(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
+	a.AgentKeeper = agentkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(a.keys[agenttypes.ModuleName]),
+		tee.NewVerifier(),
+		a.BankKeeper,
+		govModuleAddress,
+	)
+
 	a.DymNSKeeper = dymnskeeper.NewKeeper(
 		appCodec,
 		a.keys[dymnstypes.StoreKey],
 		a.BankKeeper,
 		a.RollappKeeper,
 		a.TxFeesKeeper,
+		a.AgentKeeper,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
@@ -593,13 +602,6 @@ func (a *AppKeepers) InitKeepers(
 		&a.HyperCoreKeeper,
 	)
 
-	a.AgentKeeper = agentkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(a.keys[agenttypes.ModuleName]),
-		tee.NewVerifier(),
-		a.BankKeeper,
-		govModuleAddress,
-	)
 	a.EIBCKeeper.SetAgentKeeper(a.AgentKeeper)
 
 	a.BridgingFeeKeeper = bridgingfeekeeper.NewKeeper(

--- a/x/agent/keeper/agent.go
+++ b/x/agent/keeper/agent.go
@@ -24,3 +24,12 @@ func (k Keeper) GetAgent(ctx sdk.Context, id string) (types.Agent, bool) {
 	}
 	return agent, true
 }
+
+// GetAgentOwner returns the owner of a registered agent and whether it exists.
+func (k Keeper) GetAgentOwner(ctx sdk.Context, agentID string) (string, bool) {
+	agent, found := k.GetAgent(ctx, agentID)
+	if !found {
+		return "", false
+	}
+	return agent.Owner, true
+}

--- a/x/agent/keeper/agent_test.go
+++ b/x/agent/keeper/agent_test.go
@@ -1,0 +1,27 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dymensionxyz/dymension/v3/x/agent/types"
+)
+
+func TestGetAgentOwner(t *testing.T) {
+	ctx, k, _ := setup(t)
+
+	const (
+		agentID    = "agent-1"
+		agentOwner = "dym1owner"
+	)
+	require.NoError(t, k.SetAgent(ctx, types.Agent{Id: agentID, Owner: agentOwner}))
+
+	gotOwner, found := k.GetAgentOwner(ctx, agentID)
+	require.True(t, found)
+	require.Equal(t, agentOwner, gotOwner)
+
+	gotOwner, found = k.GetAgentOwner(ctx, "missing-agent")
+	require.False(t, found)
+	require.Empty(t, gotOwner)
+}

--- a/x/dymns/keeper/keeper.go
+++ b/x/dymns/keeper/keeper.go
@@ -20,6 +20,7 @@ type Keeper struct {
 	bankKeeper    dymnstypes.BankKeeper
 	rollappKeeper dymnstypes.RollAppKeeper
 	txFeesKeeper  dymnstypes.TxFeesKeeper
+	agentKeeper   dymnstypes.AgentKeeper
 }
 
 // NewKeeper returns a new instance of the DymNS keeper
@@ -29,6 +30,7 @@ func NewKeeper(
 	bk dymnstypes.BankKeeper,
 	rk dymnstypes.RollAppKeeper,
 	tk dymnstypes.TxFeesKeeper,
+	ak dymnstypes.AgentKeeper,
 	authority string,
 ) Keeper {
 	return Keeper{
@@ -38,6 +40,7 @@ func NewKeeper(
 		bankKeeper:    bk,
 		rollappKeeper: rk,
 		txFeesKeeper:  tk,
+		agentKeeper:   ak,
 	}
 }
 

--- a/x/dymns/keeper/keeper_suite_test.go
+++ b/x/dymns/keeper/keeper_suite_test.go
@@ -56,6 +56,7 @@ type KeeperTestSuite struct {
 	dymNsKeeper   dymnskeeper.Keeper
 	rollAppKeeper rollappkeeper.Keeper
 	bankKeeper    dymnstypes.BankKeeper
+	agentKeeper   *agentKeeperMock
 
 	dymNsStoreKey   storetypes.StoreKey
 	rollappStoreKey storetypes.StoreKey
@@ -76,6 +77,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	var dk dymnskeeper.Keeper
 	var bk dymnstypes.BankKeeper
 	var rk *rollappkeeper.Keeper
+	var agentk *agentKeeperMock
 	var keys map[string]*storetypes.KVStoreKey
 
 	{
@@ -133,11 +135,13 @@ func (s *KeeperTestSuite) SetupTest() {
 			bankKeeper: bk,
 		}
 
+		agentk = &agentKeeperMock{owners: make(map[string]string)}
 		dk = dymnskeeper.NewKeeper(cdc,
 			keys[dymnstypes.StoreKey],
 			bk,
 			rk,
 			txfeesk,
+			agentk,
 			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		)
 
@@ -157,6 +161,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.dymNsKeeper = dk
 	s.rollAppKeeper = *rk
 	s.bankKeeper = bk
+	s.agentKeeper = agentk
 	s.dymNsStoreKey = keys[dymnstypes.StoreKey]
 	s.rollappStoreKey = keys[rollapptypes.StoreKey]
 
@@ -173,6 +178,15 @@ func (s *KeeperTestSuite) SetupTest() {
 	// others
 
 	s.SaveCurrentContext()
+}
+
+type agentKeeperMock struct {
+	owners map[string]string
+}
+
+func (m *agentKeeperMock) GetAgentOwner(_ sdk.Context, agentID string) (string, bool) {
+	owner, found := m.owners[agentID]
+	return owner, found
 }
 
 func (s *KeeperTestSuite) AfterTest(_, _ string) {

--- a/x/dymns/keeper/msg_server_set_service_record.go
+++ b/x/dymns/keeper/msg_server_set_service_record.go
@@ -24,6 +24,15 @@ func (k msgServer) SetServiceRecord(goCtx context.Context, msg *dymnstypes.MsgSe
 
 	_, newConfig := msg.GetDymNameConfig()
 	newConfigIdentity := newConfig.GetIdentity()
+	if !newConfig.IsDelete() && msg.ServiceKey == dymnstypes.ReservedServiceKeyAgent {
+		owner, found := k.agentKeeper.GetAgentOwner(ctx, msg.Value)
+		if !found {
+			return nil, errorsmod.Wrap(gerrc.ErrNotFound, "agent not registered")
+		}
+		if owner != dymName.Owner {
+			return nil, errorsmod.Wrap(gerrc.ErrPermissionDenied, "agent owner does not match Dym-Name owner")
+		}
+	}
 
 	var minimumTxGasRequired storetypes.Gas
 

--- a/x/dymns/keeper/msg_server_set_service_record_test.go
+++ b/x/dymns/keeper/msg_server_set_service_record_test.go
@@ -67,6 +67,97 @@ func (s *KeeperTestSuite) Test_msgServer_SetServiceRecord_AddUpdateDelete() {
 	s.Require().Empty(s.dymNsKeeper.GetServiceRecords(s.ctx, name))
 }
 
+func (s *KeeperTestSuite) Test_msgServer_SetServiceRecord_AgentBinding() {
+	s.RefreshContext()
+
+	const (
+		name    = "agent"
+		agentID = "agent-1"
+	)
+	dymName := s.setupServiceRecordDymName(name)
+	dymName.Controller = testAddr(2).bech32()
+	s.Require().NoError(s.dymNsKeeper.SetDymName(s.ctx, dymName))
+	s.agentKeeper.owners[agentID] = dymName.Owner
+
+	_, err := dymnskeeper.NewMsgServerImpl(s.dymNsKeeper).SetServiceRecord(s.ctx, &dymnstypes.MsgSetServiceRecord{
+		Name:       name,
+		Controller: dymName.Controller,
+		ServiceKey: "agent",
+		Value:      agentID,
+	})
+	s.Require().NoError(err)
+
+	serviceResp, err := dymnskeeper.NewQueryServerImpl(s.dymNsKeeper).DymNameService(s.ctx, &dymnstypes.QueryDymNameServiceRequest{
+		Name:       name,
+		ServiceKey: "agent",
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(agentID, serviceResp.Value)
+}
+
+func (s *KeeperTestSuite) Test_msgServer_SetServiceRecord_AgentBindingRejectsMissingAgent() {
+	s.RefreshContext()
+
+	dymName := s.setupServiceRecordDymName("agent")
+	_, err := dymnskeeper.NewMsgServerImpl(s.dymNsKeeper).SetServiceRecord(s.ctx, &dymnstypes.MsgSetServiceRecord{
+		Name:       dymName.Name,
+		Controller: dymName.Controller,
+		ServiceKey: "agent",
+		Value:      "missing-agent",
+	})
+	s.Require().ErrorIs(err, gerrc.ErrNotFound)
+	s.Require().Contains(err.Error(), "agent not registered")
+}
+
+func (s *KeeperTestSuite) Test_msgServer_SetServiceRecord_AgentBindingRejectsDifferentOwner() {
+	s.RefreshContext()
+
+	dymName := s.setupServiceRecordDymName("agent")
+	s.agentKeeper.owners["agent-1"] = testAddr(2).bech32()
+
+	_, err := dymnskeeper.NewMsgServerImpl(s.dymNsKeeper).SetServiceRecord(s.ctx, &dymnstypes.MsgSetServiceRecord{
+		Name:       dymName.Name,
+		Controller: dymName.Controller,
+		ServiceKey: "agent",
+		Value:      "agent-1",
+	})
+	s.Require().ErrorIs(err, gerrc.ErrPermissionDenied)
+	s.Require().Contains(err.Error(), "agent owner does not match Dym-Name owner")
+}
+
+func (s *KeeperTestSuite) Test_msgServer_SetServiceRecord_AgentBindingDeleteBypassesLookup() {
+	s.RefreshContext()
+
+	dymName := s.setupServiceRecordDymName("agent", dymnstypes.DymNameConfig{
+		Type:  dymnstypes.DymNameConfigType_DCT_SERVICE,
+		Path:  "agent",
+		Value: "removed-agent",
+	})
+
+	_, err := dymnskeeper.NewMsgServerImpl(s.dymNsKeeper).SetServiceRecord(s.ctx, &dymnstypes.MsgSetServiceRecord{
+		Name:       dymName.Name,
+		Controller: dymName.Controller,
+		ServiceKey: "agent",
+		Value:      "",
+	})
+	s.Require().NoError(err)
+	s.Require().Empty(s.dymNsKeeper.GetServiceRecord(s.ctx, dymName.Name, "agent"))
+}
+
+func (s *KeeperTestSuite) Test_msgServer_SetServiceRecord_NonAgentKeyBypassesLookup() {
+	s.RefreshContext()
+
+	dymName := s.setupServiceRecordDymName("agent")
+	_, err := dymnskeeper.NewMsgServerImpl(s.dymNsKeeper).SetServiceRecord(s.ctx, &dymnstypes.MsgSetServiceRecord{
+		Name:       dymName.Name,
+		Controller: dymName.Controller,
+		ServiceKey: "mcp",
+		Value:      "unregistered-agent-id",
+	})
+	s.Require().NoError(err)
+	s.Require().Equal("unregistered-agent-id", s.dymNsKeeper.GetServiceRecord(s.ctx, dymName.Name, "mcp"))
+}
+
 func (s *KeeperTestSuite) Test_msgServer_SetServiceRecord_Rejections() {
 	const name = "agent"
 

--- a/x/dymns/types/constants.go
+++ b/x/dymns/types/constants.go
@@ -16,6 +16,9 @@ const (
 	// MaxServiceValueLength is the maximum length allowed for a service record endpoint value.
 	MaxServiceValueLength = 256
 
+	// ReservedServiceKeyAgent binds a service record to an x/agent identity.
+	ReservedServiceKeyAgent = "agent"
+
 	// MinDymNamePriceStepsCount is the minimum number of price steps required for Dym-Name price.
 	MinDymNamePriceStepsCount = 4
 

--- a/x/dymns/types/expected_keepers.go
+++ b/x/dymns/types/expected_keepers.go
@@ -28,3 +28,9 @@ type TxFeesKeeper interface {
 	CalcBaseInCoin(ctx sdk.Context, inputCoin sdk.Coin, denom string) (sdk.Coin, error)
 	ChargeFeesFromPayer(ctx sdk.Context, payer sdk.AccAddress, takerFeeCoin sdk.Coin, beneficiary *sdk.AccAddress) error
 }
+
+// AgentKeeper defines the read-only x/agent functionality needed by x/dymns.
+type AgentKeeper interface {
+	// GetAgentOwner returns the owner bech32 of a registered agent and whether it exists.
+	GetAgentOwner(ctx sdk.Context, agentID string) (owner string, found bool)
+}


### PR DESCRIPTION
Closes #2203

DCT_SERVICE records under the reserved `agent` key now require a registered x/agent identity owned by the same principal that owns the Dym-Name. This adds provenance to agent discovery while preserving delegated controllers, deletions, inactive-agent lifecycle, and every non-reserved service key.

- Adds a minimal read-only x/agent ownership seam.
- Enforces existence and owner equality in the stateful message handler.
- Covers success/query, missing identity, owner mismatch, deletion, delegation, and non-agent regression behavior.

<details><summary>Implementation mechanics</summary>

- `x/agent` exposes `GetAgentOwner` as a thin wrapper over `GetAgent`.
- `x/dymns` injects the AgentKeeper and reserves service key `agent`.
- Non-delete writes return `ErrNotFound` for unknown agents and `ErrPermissionDenied` for ownership mismatch.
- Deletes bypass agent lookup, and no liveness check, migration, message, record type, reverse index, or query is added.

</details>

## Proof of execution

- **Build and Test — PASS:** local CI-equivalent `go build ./... && go test -race ./...` completed with exit 0; GitHub Build and Test re-runs this coverage.
- **golangci-lint — PASS:** `golangci-lint run --allow-serial-runners` reported `0 issues.`; GitHub golangci-lint re-runs this gate.
- **Formatting — PASS:** gofumpt reported no touched files and `git diff --check` exited 0.
- **Independent Go review — PASS:** no critical, important, or minor findings; consensus safety, wiring order, errors, and acceptance coverage confirmed.

**Not verified:** nothing; all changed backend behavior is covered by automated keeper tests and the repository-wide build, race, lint, and formatting gates.