### PR TITLE
feat(ante): check circuit breaker for wrapped msgs

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -13,12 +13,15 @@ import (
 	circuitkeeper "cosmossdk.io/x/circuit/keeper"
 	circuittypes "cosmossdk.io/x/circuit/types"
 	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/evmos/ethermint/crypto/ethsecp256k1"
 	"github.com/evmos/ethermint/ethereum/eip712"
 
@@ -121,6 +124,72 @@ func (suite *AnteTestSuite) TestCircuitBreaker() {
 	// Try again - should pass
 	_, err = suite.anteHandler(suite.ctx, suite.txBuilder.GetTx(), false)
 	suite.Require().NotContains(err.Error(), "tx type not allowed") // not circuit breaker error
+}
+
+// The SDK's CircuitBreakerDecorator only inspects top level msgs, so wrapped ones are covered
+// by our RejectMessagesDecorator predicate instead.
+func (suite *AnteTestSuite) TestCircuitBreakerWrappedMsgs() {
+	msgSend := &banktypes.MsgSend{
+		FromAddress: "cosmos1...",
+		ToAddress:   "cosmos1...",
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin("stake", 1000)),
+	}
+	sendURL := sdk.MsgTypeURL(msgSend)
+
+	wrap := map[string]func(*codectypes.Any) sdk.Msg{
+		"authz MsgExec": func(inner *codectypes.Any) sdk.Msg {
+			return &authz.MsgExec{Grantee: "cosmos1...", Msgs: []*codectypes.Any{inner}}
+		},
+		"gov v1 MsgSubmitProposal": func(inner *codectypes.Any) sdk.Msg {
+			return &govtypesv1.MsgSubmitProposal{
+				Messages:       []*codectypes.Any{inner},
+				InitialDeposit: sdk.NewCoins(sdk.NewInt64Coin("stake", 1000)),
+				Proposer:       "cosmos1...",
+			}
+		},
+	}
+
+	for name, wrapFn := range wrap {
+		suite.Run(name, func() {
+			// fresh app per case, so circuit breaker state cannot leak between them
+			suite.SetupTestCheckTx(false)
+
+			circuitMsgServ := circuitkeeper.NewMsgServerImpl(suite.app.CircuitBreakerKeeper)
+			authority, err := suite.app.AccountKeeper.AddressCodec().BytesToString(suite.app.CircuitBreakerKeeper.GetAuthority())
+			suite.Require().NoError(err)
+
+			msg := wrapFn(packMsg(suite.T(), msgSend))
+			runAnte := func() error {
+				txBuilder := suite.clientCtx.TxConfig.NewTxBuilder()
+				txBuilder.SetGasLimit(200000)
+				suite.Require().NoError(txBuilder.SetMsgs(msg))
+				_, err := suite.anteHandler(suite.ctx, txBuilder.GetTx(), false)
+				return err
+			}
+
+			if err := runAnte(); err != nil {
+				suite.Require().NotContains(err.Error(), "disabled: "+sendURL)
+			}
+
+			_, err = circuitMsgServ.TripCircuitBreaker(suite.ctx, &circuittypes.MsgTripCircuitBreaker{
+				Authority:   authority,
+				MsgTypeUrls: []string{sendURL},
+			})
+			suite.Require().NoError(err)
+
+			suite.Require().ErrorContains(runAnte(), "disabled: "+sendURL)
+
+			_, err = circuitMsgServ.ResetCircuitBreaker(suite.ctx, &circuittypes.MsgResetCircuitBreaker{
+				Authority:   authority,
+				MsgTypeUrls: []string{sendURL},
+			})
+			suite.Require().NoError(err)
+
+			if err := runAnte(); err != nil {
+				suite.Require().NotContains(err.Error(), "disabled: "+sendURL)
+			}
+		})
+	}
 }
 
 func (suite *AnteTestSuite) CreateTestEIP712CosmosTxBuilder(

--- a/app/ante/cosmos_handler.go
+++ b/app/ante/cosmos_handler.go
@@ -30,7 +30,9 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 			WithPredicate(BlockTypeUrls(
 				0,
 				sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
-				sdk.MsgTypeURL(&ibcclienttypes.MsgSubmitMisbehaviour{}))), // blocked to avoid skipping our validation logic in lightclient ante handler
+				sdk.MsgTypeURL(&ibcclienttypes.MsgSubmitMisbehaviour{}))). // blocked to avoid skipping our validation logic in lightclient ante handler
+			// extends the circuit breaker above, which only sees top level msgs
+			WithPredicate(BlockTrippedByCircuitBreaker(options.CircuitKeeper)),
 
 		// Use Mempool Fee TransferEnabledDecorator from our txfees module instead of default one from auth
 		mempoolFeeDecorator,

--- a/app/ante/reject_msgs.go
+++ b/app/ante/reject_msgs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
+	circuitante "cosmossdk.io/x/circuit/ante"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/authz"
@@ -23,7 +24,7 @@ type RejectMessagesDecorator struct {
 }
 
 // Predicate should return true if message is not allowed
-type Predicate = func(typeURL string, depth int) bool
+type Predicate = func(ctx sdk.Context, typeURL string, depth int) bool
 
 // Blocks any message with depth of depthMax OR MORE
 // Depth 0 is top level message
@@ -33,9 +34,21 @@ func BlockTypeUrls(depthMax int, typeUrls ...string) Predicate {
 	for _, url := range typeUrls {
 		block[url] = struct{}{}
 	}
-	return func(url string, depth int) bool {
+	return func(_ sdk.Context, url string, depth int) bool {
 		_, ok := block[url]
 		return ok && depthMax <= depth
+	}
+}
+
+// BlockTrippedByCircuitBreaker blocks, at any depth, messages whose type is currently tripped
+// in the circuit breaker. The SDK's own CircuitBreakerDecorator deliberately only inspects
+// top level messages, so a tripped type wrapped in authz/gov/group would otherwise be admitted
+// to the mempool and only fail later in baseapp's msg router.
+// A keeper error fails closed: baseapp re-checks and surfaces the real error at execution.
+func BlockTrippedByCircuitBreaker(ck circuitante.CircuitBreaker) Predicate {
+	return func(ctx sdk.Context, url string, _ int) bool {
+		allowed, err := ck.IsAllowed(ctx, url)
+		return err != nil || !allowed
 	}
 }
 
@@ -90,7 +103,7 @@ func (rmd RejectMessagesDecorator) checkMsg(ctx sdk.Context, msg sdk.Msg, depth 
 
 	typeURL := sdk.MsgTypeURL(msg)
 	for _, pred := range rmd.predicates {
-		if pred(typeURL, depth) {
+		if pred(ctx, typeURL, depth) {
 			return gerrc.ErrInvalidArgument.Wrapf("disabled: %s", typeURL)
 		}
 	}
@@ -112,7 +125,7 @@ func (rmd RejectMessagesDecorator) checkMsg(ctx sdk.Context, msg sdk.Msg, depth 
 		}
 		typeURL = authorization.MsgTypeURL()
 		for _, pred := range rmd.predicates {
-			if pred(typeURL, depth) {
+			if pred(ctx, typeURL, depth) {
 				return gerrc.ErrInvalidArgument.Wrapf("disabled grant: %s", typeURL)
 			}
 		}

--- a/app/ante/reject_msgs.go
+++ b/app/ante/reject_msgs.go
@@ -23,8 +23,10 @@ type RejectMessagesDecorator struct {
 	predicates []Predicate
 }
 
-// Predicate should return true if message is not allowed
-type Predicate = func(ctx sdk.Context, typeURL string, depth int) bool
+// Predicate should return true if message is not allowed.
+// A non nil error means the policy could not be evaluated at all, which is distinct from
+// the message being disallowed, and must not be reported as the latter.
+type Predicate = func(ctx sdk.Context, typeURL string, depth int) (bool, error)
 
 // Blocks any message with depth of depthMax OR MORE
 // Depth 0 is top level message
@@ -34,9 +36,9 @@ func BlockTypeUrls(depthMax int, typeUrls ...string) Predicate {
 	for _, url := range typeUrls {
 		block[url] = struct{}{}
 	}
-	return func(_ sdk.Context, url string, depth int) bool {
+	return func(_ sdk.Context, url string, depth int) (bool, error) {
 		_, ok := block[url]
-		return ok && depthMax <= depth
+		return ok && depthMax <= depth, nil
 	}
 }
 
@@ -44,11 +46,14 @@ func BlockTypeUrls(depthMax int, typeUrls ...string) Predicate {
 // in the circuit breaker. The SDK's own CircuitBreakerDecorator deliberately only inspects
 // top level messages, so a tripped type wrapped in authz/gov/group would otherwise be admitted
 // to the mempool and only fail later in baseapp's msg router.
-// A keeper error fails closed: baseapp re-checks and surfaces the real error at execution.
 func BlockTrippedByCircuitBreaker(ck circuitante.CircuitBreaker) Predicate {
-	return func(ctx sdk.Context, url string, _ int) bool {
+	return func(ctx sdk.Context, url string, _ int) (bool, error) {
 		allowed, err := ck.IsAllowed(ctx, url)
-		return err != nil || !allowed
+		if err != nil {
+			// fail closed, but the caller surfaces err rather than claiming a deliberate trip
+			return true, err
+		}
+		return !allowed, nil
 	}
 }
 
@@ -88,6 +93,20 @@ func (rmd RejectMessagesDecorator) checkMsgs(ctx sdk.Context, msgs []sdk.Msg, de
 	return nil
 }
 
+// rejection labels the reason, e.g. 'disabled' for a msg and 'disabled grant' for what a grant authorizes
+func (rmd RejectMessagesDecorator) checkPredicates(ctx sdk.Context, typeURL string, depth int, rejection string) error {
+	for _, pred := range rmd.predicates {
+		blocked, err := pred(ctx, typeURL, depth)
+		if err != nil {
+			return errorsmod.Wrapf(err, "check msg: %s", typeURL)
+		}
+		if blocked {
+			return gerrc.ErrInvalidArgument.Wrapf("%s: %s", rejection, typeURL)
+		}
+	}
+	return nil
+}
+
 // depth=0 means top level message
 func (rmd RejectMessagesDecorator) checkMsg(ctx sdk.Context, msg sdk.Msg, depth int) error {
 	if depth >= maxInnerDepth {
@@ -101,11 +120,8 @@ func (rmd RejectMessagesDecorator) checkMsg(ctx sdk.Context, msg sdk.Msg, depth 
 		)
 	}
 
-	typeURL := sdk.MsgTypeURL(msg)
-	for _, pred := range rmd.predicates {
-		if pred(ctx, typeURL, depth) {
-			return gerrc.ErrInvalidArgument.Wrapf("disabled: %s", typeURL)
-		}
+	if err := rmd.checkPredicates(ctx, sdk.MsgTypeURL(msg), depth, "disabled"); err != nil {
+		return err
 	}
 
 	var err error
@@ -123,11 +139,8 @@ func (rmd RejectMessagesDecorator) checkMsg(ctx sdk.Context, msg sdk.Msg, depth 
 		if err != nil {
 			return err
 		}
-		typeURL = authorization.MsgTypeURL()
-		for _, pred := range rmd.predicates {
-			if pred(ctx, typeURL, depth) {
-				return gerrc.ErrInvalidArgument.Wrapf("disabled grant: %s", typeURL)
-			}
+		if err := rmd.checkPredicates(ctx, authorization.MsgTypeURL(), depth, "disabled grant"); err != nil {
+			return err
 		}
 	default:
 	}

--- a/app/ante/reject_msgs_test.go
+++ b/app/ante/reject_msgs_test.go
@@ -203,26 +203,64 @@ func (suite *AnteTestSuite) TestRejectMessagesDecorator() {
 	}
 }
 
-// reports the msg as allowed, so only the error can cause a rejection
-type erroringCircuitBreaker struct{}
+var errCircuitUnavailable = errors.New("circuit state unavailable")
 
-func (erroringCircuitBreaker) IsAllowed(context.Context, string) (bool, error) {
-	return true, errors.New("circuit keeper unavailable")
+// reports every msg as allowed, erroring only for failFor, so a rejection can only come
+// from the error and never from the msg being genuinely tripped
+type erroringCircuitBreaker struct{ failFor string }
+
+func (c erroringCircuitBreaker) IsAllowed(_ context.Context, typeURL string) (bool, error) {
+	if typeURL == c.failFor {
+		return true, errCircuitUnavailable
+	}
+	return true, nil
 }
 
+// A circuit keeper error must reject the tx but stay diagnosable: the ante handler is terminal,
+// so anything it discards here is lost for good rather than resurfaced by baseapp.
 func (suite *AnteTestSuite) TestCircuitBreakerPredicateFailsClosed() {
-	suite.SetupTestCheckTx(false)
+	sendURL := sdk.MsgTypeURL(&banktypes.MsgSend{})
 
-	decorator := ante.NewRejectMessagesDecorator().
-		WithPredicate(ante.BlockTrippedByCircuitBreaker(erroringCircuitBreaker{}))
+	testCases := []struct {
+		name string
+		msg  sdk.Msg
+	}{
+		{
+			name: "msg",
+			msg: &banktypes.MsgSend{
+				FromAddress: "cosmos1...",
+				ToAddress:   "cosmos1...",
+				Amount:      sdk.NewCoins(sdk.NewInt64Coin("stake", 1000)),
+			},
+		},
+		{
+			name: "authz MsgGrant authorization",
+			msg: &authz.MsgGrant{
+				Granter: "cosmos1...",
+				Grantee: "cosmos1...",
+				Grant: authz.Grant{
+					Authorization: packAuthorization(suite.T(), &authz.GenericAuthorization{Msg: sendURL}),
+				},
+			},
+		},
+	}
 
-	msg := &banktypes.MsgMultiSend{}
-	tx := &mockTx{msgs: []sdk.Msg{msg}}
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTestCheckTx(false)
 
-	ctx := suite.ctx.WithBlockHeight(1)
-	_, err := decorator.AnteHandle(ctx, tx, false, func(sdk.Context, sdk.Tx, bool) (sdk.Context, error) { return ctx, nil })
+			decorator := ante.NewRejectMessagesDecorator().
+				WithPredicate(ante.BlockTrippedByCircuitBreaker(erroringCircuitBreaker{failFor: sendURL}))
 
-	suite.Require().ErrorContains(err, "disabled: "+sdk.MsgTypeURL(msg))
+			ctx := suite.ctx.WithBlockHeight(1)
+			_, err := decorator.AnteHandle(ctx, &mockTx{msgs: []sdk.Msg{tc.msg}}, false,
+				func(sdk.Context, sdk.Tx, bool) (sdk.Context, error) { return ctx, nil })
+
+			suite.Require().Error(err, "must fail closed")
+			suite.Require().ErrorIs(err, errCircuitUnavailable, "keeper error must stay discoverable")
+			suite.Require().NotContains(err.Error(), "disabled", "must not be reported as a deliberate trip")
+		})
+	}
 }
 
 func packMsg(t *testing.T, msg sdk.Msg) *codectypes.Any {

--- a/app/ante/reject_msgs_test.go
+++ b/app/ante/reject_msgs_test.go
@@ -1,6 +1,8 @@
 package ante_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -199,6 +201,28 @@ func (suite *AnteTestSuite) TestRejectMessagesDecorator() {
 			}
 		})
 	}
+}
+
+// reports the msg as allowed, so only the error can cause a rejection
+type erroringCircuitBreaker struct{}
+
+func (erroringCircuitBreaker) IsAllowed(context.Context, string) (bool, error) {
+	return true, errors.New("circuit keeper unavailable")
+}
+
+func (suite *AnteTestSuite) TestCircuitBreakerPredicateFailsClosed() {
+	suite.SetupTestCheckTx(false)
+
+	decorator := ante.NewRejectMessagesDecorator().
+		WithPredicate(ante.BlockTrippedByCircuitBreaker(erroringCircuitBreaker{}))
+
+	msg := &banktypes.MsgMultiSend{}
+	tx := &mockTx{msgs: []sdk.Msg{msg}}
+
+	ctx := suite.ctx.WithBlockHeight(1)
+	_, err := decorator.AnteHandle(ctx, tx, false, func(sdk.Context, sdk.Tx, bool) (sdk.Context, error) { return ctx, nil })
+
+	suite.Require().ErrorContains(err, "disabled: "+sdk.MsgTypeURL(msg))
 }
 
 func packMsg(t *testing.T, msg sdk.Msg) *codectypes.Any {


### PR DESCRIPTION
Closes #1827

The Cosmos SDK's `CircuitBreakerDecorator` only inspects a transaction's top-level messages — a deliberate upstream tradeoff to avoid extra module dependencies in `x/circuit`, with the SDK docs telling chains to re-implement the check themselves if they want it. So a tripped message type wrapped in an authz `MsgExec` or a gov/group `MsgSubmitProposal` passed our ante handler untouched and was admitted to the mempool, only failing later in baseapp's message router at execution time. This was never a security hole — baseapp always caught it — but tripped transactions were reaching blocks just to fail there.

This change closes the gap at the ante stage by reusing the decorator we already have for exactly this shape of problem, rather than forking the SDK's decorator.

<details><summary>Mechanics</summary>

The repo already has `RejectMessagesDecorator`, which recursively walks the inner messages of authz `MsgExec` and gov/group `MsgSubmitProposal` (bounded by `maxInnerDepth`), applying a list of predicates at every depth. The circuit breaker check is now just another predicate on it.

- Added a predicate built from the `circuitante.CircuitBreaker` interface that consults `IsAllowed` for the message type. It applies at every depth; re-checking depth 0 duplicates the stock decorator but keeps the predicate branch-free.
- `Predicate` returns `(blocked bool, err error)`. A policy rejection and a failure to evaluate policy are different outcomes and must not be conflated: the ante handler is terminal, so an error discarded here is lost for good rather than resurfaced later. A circuit keeper error still fails closed, but the original error propagates wrapped, so `errors.Is` and operator diagnosis keep working — matching how the upstream SDK decorator returns `IsAllowed` errors directly.
- Both predicate evaluation points — the message type and the type an `authz.MsgGrant` authorizes — go through one helper, so the error and rejection handling cannot drift apart.
- The `Predicate` signature also takes an `sdk.Context`, which the keeper lookup needs. `checkMsg` already threaded the context, so this was contained to the type alias and its call sites.
- The SDK's `circuitante.NewCircuitBreakerDecorator` stays installed unchanged in both ante chains — the predicate supplements it, keeping drift from upstream minimal.
- The EVM ante chain needs nothing: `MsgEthereumTx` cannot wrap cosmos messages, and the cosmos chain already blocks `MsgEthereumTx` at all depths.

Intended side effect: because `RejectMessagesDecorator` also screens `authz.MsgGrant` authorization type URLs through the same predicates, granting authz for a currently-tripped message type is rejected while the breaker is tripped. That is consistent defense in depth, not a regression.

</details>

## Proof of execution

- **Wrapped tripped msg is rejected at ante (authz `MsgExec` and gov `MsgSubmitProposal`)** — `TestCircuitBreakerWrappedMsgs`, green in the `build` CI suite.
- **Top-level rejection unchanged** — pre-existing `TestCircuitBreaker`, green in the `build` CI suite.
- **No false rejection when nothing is tripped, before trip and after reset** — asserted inside `TestCircuitBreakerWrappedMsgs`, green in the `build` CI suite.
- **Circuit keeper error fails closed AND stays diagnosable, on both the msg and the grant path** — `TestCircuitBreakerPredicateFailsClosed`, green in the `build` CI suite.
- **Full repository suite** — `go test ./...`, 64 packages ok, 0 failures, green in the `build` CI suite.
- **Lint and format** — `golangci-lint run ./app/...` reports 0 issues; `gofumpt -l .` clean. Covered by the `golangci-lint` CI suite. See the fold below for pre-existing whole-repo findings unrelated to this change.
- **Both new tests genuinely catch their bug** — negative controls, not covered by CI; evidence folded below.

<details><summary>Negative control 1: wrapped-msg tests fail without the recursive check</summary>

With the production wiring reverted (predicate removed from the cosmos ante chain) and the new tests left in place, both wrapped cases fail — the wrapped message sails past `RejectMessagesDecorator` and only stops at the fee decorator, which is precisely the reported behavior:

```
--- FAIL: TestAnteTestSuite/TestCircuitBreakerWrappedMsgs (0.16s)
    --- FAIL: TestAnteTestSuite/TestCircuitBreakerWrappedMsgs/authz_MsgExec (0.10s)
        Error: Error "fee payer address:  does not exist: unknown address" does not contain "disabled: /cosmos.bank.v1beta1.MsgSend"
    --- FAIL: TestAnteTestSuite/TestCircuitBreakerWrappedMsgs/gov_v1_MsgSubmitProposal (0.06s)
        Error: Error "fee payer address:  does not exist: unknown address" does not contain "disabled: /cosmos.bank.v1beta1.MsgSend"
FAIL	github.com/dymensionxyz/dymension/v3/app/ante	0.335s
```

Each wrapper case builds its own app so circuit breaker state cannot leak between subtests.

</details>

<details><summary>Negative control 2: error-preservation tests fail if the keeper error is swallowed</summary>

Restoring the collapsed `return err != nil || !allowed, nil` form makes both paths fail, confirming the test locks in error preservation rather than merely rejection:

```
--- FAIL: TestAnteTestSuite/TestCircuitBreakerPredicateFailsClosed (0.16s)
    --- FAIL: TestAnteTestSuite/TestCircuitBreakerPredicateFailsClosed/msg (0.10s)
        Error: Target error should be in err chain:
    --- FAIL: TestAnteTestSuite/TestCircuitBreakerPredicateFailsClosed/authz_MsgGrant_authorization (0.06s)
        Error: Target error should be in err chain:
FAIL	github.com/dymensionxyz/dymension/v3/app/ante	0.320s
```

With the fix in place the whole `app/ante` package passes:

```
--- PASS: TestAnteTestSuite (0.82s)
    --- PASS: TestAnteTestSuite/TestCircuitBreaker (0.14s)
    --- PASS: TestAnteTestSuite/TestCircuitBreakerPredicateFailsClosed (0.12s)
        --- PASS: TestAnteTestSuite/TestCircuitBreakerPredicateFailsClosed/msg (0.06s)
        --- PASS: TestAnteTestSuite/TestCircuitBreakerPredicateFailsClosed/authz_MsgGrant_authorization (0.06s)
    --- PASS: TestAnteTestSuite/TestCircuitBreakerWrappedMsgs (0.11s)
        --- PASS: TestAnteTestSuite/TestCircuitBreakerWrappedMsgs/authz_MsgExec (0.05s)
        --- PASS: TestAnteTestSuite/TestCircuitBreakerWrappedMsgs/gov_v1_MsgSubmitProposal (0.05s)
ok  	github.com/dymensionxyz/dymension/v3/app/ante
```

</details>

<details><summary>Pre-existing whole-repo lint findings, reproduced on the merge base</summary>

`golangci-lint run` over the whole repo reports 7 issues (4 gosec, 3 staticcheck) in `x/dymns`, `x/forward` and `x/rollapp` — none of which this PR touches. Reproduced identically with these changes stashed, at merge base `945d7361`:

```
x/rollapp/keeper/invariants.go:76:5: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
7 issues:
* gosec: 4
* staticcheck: 3
```

Scoped to the changed package, `golangci-lint run ./app/...` reports `0 issues`.

</details>

<details><summary>Shared-fixture scope</summary>

`Predicate` is a type alias whose every consumer lives inside `app/ante`: one production construction site (`cosmos_handler.go`), three in tests, and the two invocation points now unified in `checkPredicates`. Verified by searching the repo for `Predicate`, `BlockTypeUrls`, `WithPredicate` and `BlockTrippedByCircuitBreaker`; no consumers outside `app/ante`. The full `go test ./...` run above covers every consuming package.

</details>