### PR TITLE
fix(rollapp): validate fraud proposal fields

### DIFF
--- a/x/rollapp/keeper/fraud_proposal.go
+++ b/x/rollapp/keeper/fraud_proposal.go
@@ -24,7 +24,7 @@ func (k Keeper) SubmitRollappFraud(goCtx context.Context, msg *types.MsgRollappF
 	}
 
 	if err := msg.ValidateBasic(); err != nil {
-		err = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid msg")
+		err = errorsmod.Wrap(err, "invalid msg")
 		ctx.Logger().Error("Fraud proposal", "error", err)
 		return nil, err
 	}

--- a/x/rollapp/keeper/fraud_proposal_test.go
+++ b/x/rollapp/keeper/fraud_proposal_test.go
@@ -112,3 +112,13 @@ func (s *RollappTestSuite) TestSubmitRollappFraud() {
 		})
 	}
 }
+
+func (s *RollappTestSuite) TestSubmitRollappFraudPreservesValidationError() {
+	msg := &types.MsgRollappFraudProposal{
+		Authority: s.App.AccountKeeper.GetModuleAddress(govtypes.ModuleName).String(),
+	}
+
+	_, err := s.k().SubmitRollappFraud(s.Ctx, msg)
+
+	s.Require().ErrorContains(err, "rollapp ID is invalid")
+}

--- a/x/rollapp/types/message_fraud_proposal.go
+++ b/x/rollapp/types/message_fraud_proposal.go
@@ -19,11 +19,28 @@ func (m *MsgRollappFraudProposal) ValidateBasic() error {
 			"authority is not a valid bech32 address: %s", m.Authority,
 		)
 	}
+	if _, err := NewChainID(m.RollappId); err != nil {
+		return errorsmod.Wrap(
+			errors.Join(gerrc.ErrInvalidArgument, err),
+			"rollapp ID is invalid",
+		)
+	}
+	if m.FraudHeight == 0 {
+		return errorsmod.Wrap(gerrc.ErrInvalidArgument, "fraud height must be greater than zero")
+	}
+	if m.PunishSequencerAddress != "" {
+		if _, err := sdk.AccAddressFromBech32(m.PunishSequencerAddress); err != nil {
+			return errorsmod.Wrapf(
+				errors.Join(gerrc.ErrInvalidArgument, err),
+				"punish sequencer address is not a valid bech32 address: %s", m.PunishSequencerAddress,
+			)
+		}
+	}
 	if m.Rewardee != "" {
 		if _, err := sdk.AccAddressFromBech32(m.Rewardee); err != nil {
 			return errorsmod.Wrapf(
 				errors.Join(gerrc.ErrInvalidArgument, err),
-				"rewardee is not a valid bech32 address: %s", m.Authority,
+				"rewardee is not a valid bech32 address: %s", m.Rewardee,
 			)
 		}
 	}

--- a/x/rollapp/types/message_fraud_proposal_test.go
+++ b/x/rollapp/types/message_fraud_proposal_test.go
@@ -1,0 +1,95 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dymensionxyz/dymension/v3/testutil/sample"
+	"github.com/dymensionxyz/dymension/v3/x/rollapp/types"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
+)
+
+func TestMsgRollappFraudProposalValidateBasic(t *testing.T) {
+	valid := types.MsgRollappFraudProposal{
+		Authority:              sample.AccAddress(),
+		RollappId:              "rollapp_1234-1",
+		FraudHeight:            1,
+		FraudRevision:          0,
+		PunishSequencerAddress: sample.AccAddress(),
+		Rewardee:               sample.AccAddress(),
+	}
+
+	tests := []struct {
+		name        string
+		modify      func(*types.MsgRollappFraudProposal)
+		wantErr     error
+		wantMessage string
+	}{
+		{
+			name: "valid message with revision zero",
+		},
+		{
+			name: "empty rollapp ID",
+			modify: func(msg *types.MsgRollappFraudProposal) {
+				msg.RollappId = ""
+			},
+			wantErr: gerrc.ErrInvalidArgument,
+		},
+		{
+			name: "malformed rollapp ID",
+			modify: func(msg *types.MsgRollappFraudProposal) {
+				msg.RollappId = "malformed"
+			},
+			wantErr: gerrc.ErrInvalidArgument,
+		},
+		{
+			name: "zero fraud height",
+			modify: func(msg *types.MsgRollappFraudProposal) {
+				msg.FraudHeight = 0
+			},
+			wantErr: gerrc.ErrInvalidArgument,
+		},
+		{
+			name: "malformed punish sequencer address",
+			modify: func(msg *types.MsgRollappFraudProposal) {
+				msg.PunishSequencerAddress = "malformed"
+			},
+			wantErr: gerrc.ErrInvalidArgument,
+		},
+		{
+			name: "empty optional punish sequencer address",
+			modify: func(msg *types.MsgRollappFraudProposal) {
+				msg.PunishSequencerAddress = ""
+			},
+		},
+		{
+			name: "malformed rewardee reports rewardee value",
+			modify: func(msg *types.MsgRollappFraudProposal) {
+				msg.Rewardee = "malformed-rewardee"
+			},
+			wantErr:     gerrc.ErrInvalidArgument,
+			wantMessage: "malformed-rewardee",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := valid
+			if tt.modify != nil {
+				tt.modify(&msg)
+			}
+
+			err := msg.ValidateBasic()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantErr)
+			if tt.wantMessage != "" {
+				require.ErrorContains(t, err, tt.wantMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1558

MsgRollappFraudProposal previously allowed malformed stateless fields through governance and could underflow a zero fraud height during execution. This change validates rollapp IDs, nonzero fraud heights, and optional punish-sequencer addresses, while preserving revision 0 and surfacing the original validation detail from the handler.

- Rejects malformed proposal fields as invalid arguments before governance execution.
- Keeps optional fields and revision-zero proposals valid.
- Corrects the rewardee diagnostic and preserves handler validation context.

<details><summary>Implementation details</summary>

- Reuses `NewChainID` for rollapp ID validation.
- Rejects `FraudHeight == 0` before the handler subtracts one.
- Validates `PunishSequencerAddress` only when supplied.
- Adds table-driven message tests and a keeper regression test.

</details>

## Proof of execution

- **Build and Test (CI): pending on GitHub; equivalent gate green locally** — `go-acc -o /tmp/issue-1558-coverage.txt ./... -- -v --race` exited 0.
- **Build and Test (CI): pending on GitHub; build green locally** — `go build -v ./...` exited 0.
- **golangci-lint (CI): green on GitHub and locally** — golangci-lint v2.1.0 reported `0 issues`.
- **CodeQL (CI): green on GitHub** — both Analyze and CodeQL checks passed.
- **Fraud proposal regressions: green** — `TestMsgRollappFraudProposalValidateBasic`, `TestSubmitRollappFraud`, and `TestSubmitRollappFraudPreservesValidationError` pass and are rerun by Build and Test CI.

**Not verified:** manually dispatched cross-repository E2E and upgrade workflows; they are not PR-gated and this change has no external endpoint, dependency, protobuf, or UI behavior.

