### PR TITLE
fix(sponsorship): adopt gerrc error taxonomy

### DIFF
--- a/x/sponsorship/keeper/msg_server.go
+++ b/x/sponsorship/keeper/msg_server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 	"github.com/dymensionxyz/sdk-utils/utils/uevent"
 
 	"github.com/dymensionxyz/dymension/v3/x/sponsorship/types"
@@ -82,7 +82,7 @@ func (m MsgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams)
 	}
 
 	if msg.Authority != m.k.authority {
-		return nil, sdkerrors.ErrorInvalidSigner.Wrapf("Only the gov module can update params")
+		return nil, gerrc.ErrUnauthenticated.Wrap("only the gov module can update params")
 	}
 
 	oldParams, err := m.k.GetParams(ctx)

--- a/x/sponsorship/keeper/msg_server_test.go
+++ b/x/sponsorship/keeper/msg_server_test.go
@@ -1,10 +1,10 @@
 package keeper_test
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/gogoproto/proto"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 
 	"github.com/dymensionxyz/dymension/v3/app/apptesting"
 	"github.com/dymensionxyz/dymension/v3/x/sponsorship/types"
@@ -38,7 +38,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 					MinVotingPower:      types.DefaultMinVotingPower,
 				},
 			},
-			error: sdkerrors.ErrorInvalidSigner,
+			error: gerrc.ErrUnauthenticated,
 		},
 		{
 			name: "invalid params",

--- a/x/sponsorship/keeper/query_server.go
+++ b/x/sponsorship/keeper/query_server.go
@@ -36,13 +36,13 @@ func (q QueryServer) Vote(goCtx context.Context, request *types.QueryVoteRequest
 
 	voter, err := sdk.AccAddressFromBech32(request.GetVoter())
 	if err != nil {
-		return nil, errorsmod.Wrap(errors.Join(gerrc.ErrInvalidArgument, err), "invalid voter address")
+		return nil, errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid voter address: %s", err)
 	}
 
 	vote, err := q.k.GetVote(ctx, voter)
 	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
-			return nil, errorsmod.Wrap(errors.Join(gerrc.ErrNotFound, err), "vote")
+			return nil, errorsmod.Wrapf(gerrc.ErrNotFound, "vote: %s", err)
 		}
 		return nil, err
 	}
@@ -63,12 +63,12 @@ func (q QueryServer) EstimateClaim(goCtx context.Context, query *types.QueryEsti
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	addr, err := sdk.AccAddressFromBech32(query.Address)
 	if err != nil {
-		return nil, errorsmod.Wrap(errors.Join(gerrc.ErrInvalidArgument, err), "invalid claimer address")
+		return nil, errorsmod.Wrapf(gerrc.ErrInvalidArgument, "invalid claimer address: %s", err)
 	}
 	reward, err := q.k.EstimateClaim(ctx, addr, query.RollappId)
 	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
-			return nil, errorsmod.Wrap(errors.Join(gerrc.ErrNotFound, err), "claim estimate")
+			return nil, errorsmod.Wrapf(gerrc.ErrNotFound, "claim estimate: %s", err)
 		}
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (q QueryServer) Endorsement(goCtx context.Context, query *types.QueryEndors
 	endorsement, err := q.k.GetEndorsement(ctx, query.RollappId)
 	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
-			return nil, errorsmod.Wrap(errors.Join(gerrc.ErrNotFound, err), "endorsement")
+			return nil, errorsmod.Wrapf(gerrc.ErrNotFound, "endorsement: %s", err)
 		}
 		return nil, err
 	}

--- a/x/sponsorship/keeper/query_server.go
+++ b/x/sponsorship/keeper/query_server.go
@@ -2,9 +2,12 @@ package keeper
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
+	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 
 	"github.com/dymensionxyz/dymension/v3/x/sponsorship/types"
 )
@@ -33,11 +36,14 @@ func (q QueryServer) Vote(goCtx context.Context, request *types.QueryVoteRequest
 
 	voter, err := sdk.AccAddressFromBech32(request.GetVoter())
 	if err != nil {
-		return nil, fmt.Errorf("invalid voter address: %w", err)
+		return nil, errorsmod.Wrap(errors.Join(gerrc.ErrInvalidArgument, err), "invalid voter address")
 	}
 
 	vote, err := q.k.GetVote(ctx, voter)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, errorsmod.Wrap(errors.Join(gerrc.ErrNotFound, err), "vote")
+		}
 		return nil, err
 	}
 
@@ -57,10 +63,13 @@ func (q QueryServer) EstimateClaim(goCtx context.Context, query *types.QueryEsti
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	addr, err := sdk.AccAddressFromBech32(query.Address)
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(errors.Join(gerrc.ErrInvalidArgument, err), "invalid claimer address")
 	}
 	reward, err := q.k.EstimateClaim(ctx, addr, query.RollappId)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, errorsmod.Wrap(errors.Join(gerrc.ErrNotFound, err), "claim estimate")
+		}
 		return nil, err
 	}
 	return &types.QueryEstimateClaimResponse{Reward: reward}, nil
@@ -70,6 +79,9 @@ func (q QueryServer) Endorsement(goCtx context.Context, query *types.QueryEndors
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	endorsement, err := q.k.GetEndorsement(ctx, query.RollappId)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, errorsmod.Wrap(errors.Join(gerrc.ErrNotFound, err), "endorsement")
+		}
 		return nil, err
 	}
 	return &types.QueryEndorsementResponse{Endorsement: endorsement}, nil

--- a/x/sponsorship/keeper/query_server_test.go
+++ b/x/sponsorship/keeper/query_server_test.go
@@ -1,0 +1,52 @@
+package keeper_test
+
+import (
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
+
+	"github.com/dymensionxyz/dymension/v3/app/apptesting"
+	"github.com/dymensionxyz/dymension/v3/x/sponsorship/keeper"
+	"github.com/dymensionxyz/dymension/v3/x/sponsorship/types"
+)
+
+func (s *KeeperTestSuite) TestQueryMissingEntitiesUseNotFound() {
+	queryServer := keeper.NewQueryServer(s.App.SponsorshipKeeper)
+	ctx := sdk.WrapSDKContext(s.Ctx)
+	voter := apptesting.CreateRandomAccounts(1)[0]
+
+	tests := []struct {
+		name  string
+		query func() error
+	}{
+		{
+			name: "vote",
+			query: func() error {
+				_, err := queryServer.Vote(ctx, &types.QueryVoteRequest{Voter: voter.String()})
+				return err
+			},
+		},
+		{
+			name: "claim estimate",
+			query: func() error {
+				_, err := queryServer.EstimateClaim(ctx, &types.QueryEstimateClaim{Address: voter.String(), RollappId: "missing"})
+				return err
+			},
+		},
+		{
+			name: "endorsement",
+			query: func() error {
+				_, err := queryServer.Endorsement(ctx, &types.QueryEndorsement{RollappId: "missing"})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := tt.query()
+			s.Require().ErrorIs(err, gerrc.ErrNotFound)
+			s.Require().ErrorIs(err, collections.ErrNotFound)
+		})
+	}
+}

--- a/x/sponsorship/keeper/query_server_test.go
+++ b/x/sponsorship/keeper/query_server_test.go
@@ -1,7 +1,7 @@
 package keeper_test
 
 import (
-	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 
@@ -46,7 +46,43 @@ func (s *KeeperTestSuite) TestQueryMissingEntitiesUseNotFound() {
 		s.Run(tt.name, func() {
 			err := tt.query()
 			s.Require().ErrorIs(err, gerrc.ErrNotFound)
-			s.Require().ErrorIs(err, collections.ErrNotFound)
+			codespace, code, _ := errorsmod.ABCIInfo(err, false)
+			s.Require().Equal(gerrc.DefaultCodespace, codespace)
+			s.Require().Equal(uint32(4), code)
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestQueryInvalidAddressesUseInvalidArgument() {
+	queryServer := keeper.NewQueryServer(s.App.SponsorshipKeeper)
+	ctx := sdk.WrapSDKContext(s.Ctx)
+
+	tests := []struct {
+		name  string
+		query func() error
+	}{
+		{
+			name: "vote",
+			query: func() error {
+				_, err := queryServer.Vote(ctx, &types.QueryVoteRequest{Voter: "invalid"})
+				return err
+			},
+		},
+		{
+			name: "claim estimate",
+			query: func() error {
+				_, err := queryServer.EstimateClaim(ctx, &types.QueryEstimateClaim{Address: "invalid"})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := tt.query()
+			codespace, code, _ := errorsmod.ABCIInfo(err, false)
+			s.Require().Equal(gerrc.DefaultCodespace, codespace)
+			s.Require().Equal(uint32(2), code)
 		})
 	}
 }

--- a/x/sponsorship/keeper/votes.go
+++ b/x/sponsorship/keeper/votes.go
@@ -1,11 +1,14 @@
 package keeper
 
 import (
+	"errors"
 	"fmt"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 	"github.com/dymensionxyz/sdk-utils/utils/uevent"
 
 	incentivestypes "github.com/dymensionxyz/dymension/v3/x/incentives/types"
@@ -33,7 +36,7 @@ func (k Keeper) Vote(ctx sdk.Context, voter sdk.AccAddress, weights []types.Gaug
 
 	// Validate that the user has min voting power
 	if vpBreakdown.TotalPower.LT(params.MinVotingPower) {
-		return types.Vote{}, types.Distribution{}, fmt.Errorf("voting power '%s' is less than min voting power expected '%s'", vpBreakdown.TotalPower, params.MinVotingPower)
+		return types.Vote{}, types.Distribution{}, gerrc.ErrFailedPrecondition.Wrapf("voting power '%s' is less than min voting power expected '%s'", vpBreakdown.TotalPower, params.MinVotingPower)
 	}
 
 	// Apply the vote weights to the power -> get a distribution update in absolute values
@@ -176,24 +179,24 @@ func (k Keeper) validateWeights(ctx sdk.Context, weights []types.GaugeWeight, mi
 	for _, weight := range weights {
 		// No gauge gets less than MinAllocationWeight
 		if weight.Weight.LT(minAllocationWeight) {
-			return fmt.Errorf("gauge weight is less than min allocation weight: gauge weight %s, min allocation %s", weight.Weight, minAllocationWeight)
+			return gerrc.ErrFailedPrecondition.Wrapf("gauge weight is less than min allocation weight: gauge weight %s, min allocation %s", weight.Weight, minAllocationWeight)
 		}
 
 		// All gauges exist
 		gauge, err := k.incentivesKeeper.GetGaugeByID(ctx, weight.GaugeId)
 		if err != nil {
-			return fmt.Errorf("failed to get gauge by id: %d: %w", weight.GaugeId, err)
+			return errorsmod.Wrapf(errors.Join(gerrc.ErrNotFound, err), "failed to get gauge by id: %d", weight.GaugeId)
 		}
 
 		// Only vote on rollapp gauges
 		_, isRA := gauge.DistributeTo.(*incentivestypes.Gauge_Rollapp)
 		if !isRA {
-			return fmt.Errorf("voting is only allowed for rollapp gauges: got %T: gaugeId %d", gauge.DistributeTo, weight.GaugeId)
+			return gerrc.ErrInvalidArgument.Wrapf("voting is only allowed for rollapp gauges: got %T: gaugeId %d", gauge.DistributeTo, weight.GaugeId)
 		}
 
 		// All gauges are perpetual
 		if !gauge.IsPerpetual {
-			return fmt.Errorf("gauge is not perpetual: %d", weight.GaugeId)
+			return gerrc.ErrInvalidArgument.Wrapf("gauge is not perpetual: %d", weight.GaugeId)
 		}
 	}
 	return nil

--- a/x/sponsorship/keeper/votes.go
+++ b/x/sponsorship/keeper/votes.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"errors"
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
@@ -25,7 +24,7 @@ func (k Keeper) Vote(ctx sdk.Context, voter sdk.AccAddress, weights []types.Gaug
 	// Validate specified weights
 	err = k.validateWeights(ctx, weights, params.MinAllocationWeight)
 	if err != nil {
-		return types.Vote{}, types.Distribution{}, fmt.Errorf("error validating weights: %w", err)
+		return types.Vote{}, types.Distribution{}, errorsmod.Wrap(err, "validate weights")
 	}
 
 	// Get the user’s total voting power from the x/staking
@@ -185,7 +184,7 @@ func (k Keeper) validateWeights(ctx sdk.Context, weights []types.GaugeWeight, mi
 		// All gauges exist
 		gauge, err := k.incentivesKeeper.GetGaugeByID(ctx, weight.GaugeId)
 		if err != nil {
-			return errorsmod.Wrapf(errors.Join(gerrc.ErrNotFound, err), "failed to get gauge by id: %d", weight.GaugeId)
+			return classifyGaugeLookupError(weight.GaugeId, err)
 		}
 
 		// Only vote on rollapp gauges
@@ -200,6 +199,13 @@ func (k Keeper) validateWeights(ctx sdk.Context, weights []types.GaugeWeight, mi
 		}
 	}
 	return nil
+}
+
+func classifyGaugeLookupError(gaugeID uint64, err error) error {
+	if err.Error() == fmt.Sprintf("gauge with ID %d does not exist", gaugeID) {
+		return errorsmod.Wrapf(gerrc.ErrNotFound, "gauge %d: %s", gaugeID, err)
+	}
+	return fmt.Errorf("get gauge %d: %w", gaugeID, err)
 }
 
 type ValidatorPower struct {

--- a/x/sponsorship/keeper/votes_internal_test.go
+++ b/x/sponsorship/keeper/votes_internal_test.go
@@ -1,0 +1,26 @@
+package keeper
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	errorsmod "cosmossdk.io/errors"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyGaugeLookupError(t *testing.T) {
+	missing := fmt.Errorf("gauge with ID 7 does not exist")
+	err := classifyGaugeLookupError(7, missing)
+	codespace, code, _ := errorsmod.ABCIInfo(err, false)
+	require.Equal(t, gerrc.DefaultCodespace, codespace)
+	require.Equal(t, uint32(4), code)
+
+	corrupt := errors.New("cannot decode gauge")
+	err = classifyGaugeLookupError(7, corrupt)
+	require.ErrorIs(t, err, corrupt)
+	codespace, code, _ = errorsmod.ABCIInfo(err, false)
+	require.Equal(t, errorsmod.UndefinedCodespace, codespace)
+	require.Equal(t, uint32(1), code)
+}

--- a/x/sponsorship/keeper/votes_test.go
+++ b/x/sponsorship/keeper/votes_test.go
@@ -4,6 +4,7 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 
 	"github.com/dymensionxyz/dymension/v3/app/apptesting"
 	incentivestypes "github.com/dymensionxyz/dymension/v3/x/incentives/types"
@@ -27,6 +28,7 @@ func (s *KeeperTestSuite) TestMsgVote() {
 		initialDistr  types.Distribution // initial test distr
 		expectedDistr types.Distribution // final distr after applying all the votes
 		expectErr     bool               // if the error is expected, the vote slice must contain only one element
+		errorIs       error
 		errorContains string
 	}{
 		{
@@ -233,6 +235,7 @@ func (s *KeeperTestSuite) TestMsgVote() {
 				},
 			},
 			expectErr:     true,
+			errorIs:       gerrc.ErrNotFound,
 			errorContains: "failed to get gauge by id: 2",
 		},
 		{
@@ -272,6 +275,7 @@ func (s *KeeperTestSuite) TestMsgVote() {
 				},
 			},
 			expectErr:     true,
+			errorIs:       gerrc.ErrFailedPrecondition,
 			errorContains: "gauge weight is less than min allocation weight: gauge weight 20000000000000000000, min allocation 30000000000000000000",
 		},
 		{
@@ -311,6 +315,7 @@ func (s *KeeperTestSuite) TestMsgVote() {
 				},
 			},
 			expectErr:     true,
+			errorIs:       gerrc.ErrFailedPrecondition,
 			errorContains: "voting power '1000000' is less than min voting power expected '2000000'",
 		},
 	}
@@ -353,6 +358,9 @@ func (s *KeeperTestSuite) TestMsgVote() {
 
 				if tc.expectErr {
 					s.Require().Error(err)
+					if tc.errorIs != nil {
+						s.Require().ErrorIs(err, tc.errorIs)
+					}
 					s.Require().ErrorContains(err, tc.errorContains)
 
 					// Check the vote is not in the state
@@ -648,6 +656,32 @@ func (s *KeeperTestSuite) TestVotingNonRollapp() {
 		},
 	})
 	s.Require().Error(err)
+	s.Require().ErrorIs(err, gerrc.ErrInvalidArgument)
 	s.Require().ErrorContains(err, "voting is only allowed for rollapp gauges")
+	s.Require().Nil(voteResp)
+}
+
+func (s *KeeperTestSuite) TestVotingNonPerpetualGauge() {
+	s.CreateDefaultRollapp()
+	const gaugeID uint64 = 1
+	gauge, err := s.App.IncentivesKeeper.GetGaugeByID(s.Ctx, gaugeID)
+	s.Require().NoError(err)
+	gauge.IsPerpetual = false
+	s.Require().NoError(s.App.IncentivesKeeper.SetGauge(s.Ctx, gauge))
+
+	val := s.CreateValidator()
+	valAddr, err := sdk.ValAddressFromBech32(val.GetOperator())
+	s.Require().NoError(err)
+	del := s.CreateDelegator(valAddr, sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(1_000_000)))
+	s.Require().NoError(s.App.SponsorshipKeeper.SaveDistribution(s.Ctx, types.NewDistribution()))
+
+	voteResp, err := s.msgServer.Vote(s.Ctx, &types.MsgVote{
+		Voter: del.GetDelegatorAddr(),
+		Weights: []types.GaugeWeight{
+			{GaugeId: gaugeID, Weight: types.DYM.MulRaw(50)},
+		},
+	})
+	s.Require().ErrorIs(err, gerrc.ErrInvalidArgument)
+	s.Require().ErrorContains(err, "gauge is not perpetual")
 	s.Require().Nil(voteResp)
 }

--- a/x/sponsorship/keeper/votes_test.go
+++ b/x/sponsorship/keeper/votes_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
@@ -236,7 +237,7 @@ func (s *KeeperTestSuite) TestMsgVote() {
 			},
 			expectErr:     true,
 			errorIs:       gerrc.ErrNotFound,
-			errorContains: "failed to get gauge by id: 2",
+			errorContains: "gauge 2: gauge with ID 2 does not exist",
 		},
 		{
 			name: "Weight is less than the min allocation",
@@ -360,6 +361,10 @@ func (s *KeeperTestSuite) TestMsgVote() {
 					s.Require().Error(err)
 					if tc.errorIs != nil {
 						s.Require().ErrorIs(err, tc.errorIs)
+						wantCodespace, wantCode, _ := errorsmod.ABCIInfo(tc.errorIs, false)
+						codespace, code, _ := errorsmod.ABCIInfo(err, false)
+						s.Require().Equal(wantCodespace, codespace)
+						s.Require().Equal(wantCode, code)
 					}
 					s.Require().ErrorContains(err, tc.errorContains)
 

--- a/x/sponsorship/types/errors.go
+++ b/x/sponsorship/types/errors.go
@@ -1,13 +1,16 @@
 package types
 
-import errorsmod "cosmossdk.io/errors"
+import (
+	errorsmod "cosmossdk.io/errors"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
+)
 
 var (
-	ErrInvalidGaugeWeight  = errorsmod.Register(ModuleName, 1, "invalid gauge weight")
-	ErrInvalidDistribution = errorsmod.Register(ModuleName, 2, "invalid gauge weight distribution")
-	ErrInvalidParams       = errorsmod.Register(ModuleName, 3, "invalid params")
-	ErrInvalidGenesis      = errorsmod.Register(ModuleName, 4, "invalid genesis")
-	ErrInvalidVote         = errorsmod.Register(ModuleName, 5, "invalid vote")
-	ErrInvalidVoterInfo    = errorsmod.Register(ModuleName, 6, "invalid voter info")
-	ErrNoEndorsers         = errorsmod.Register(ModuleName, 7, "no endorsers")
+	ErrInvalidGaugeWeight  = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid gauge weight")
+	ErrInvalidDistribution = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid gauge weight distribution")
+	ErrInvalidParams       = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid params")
+	ErrInvalidGenesis      = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid genesis")
+	ErrInvalidVote         = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid vote")
+	ErrInvalidVoterInfo    = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid voter info")
+	ErrNoEndorsers         = errorsmod.Wrap(gerrc.ErrFailedPrecondition, "no endorsers")
 )

--- a/x/sponsorship/types/errors.go
+++ b/x/sponsorship/types/errors.go
@@ -2,15 +2,15 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
-	"github.com/dymensionxyz/gerr-cosmos/gerrc"
+	"google.golang.org/grpc/codes"
 )
 
 var (
-	ErrInvalidGaugeWeight  = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid gauge weight")
-	ErrInvalidDistribution = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid gauge weight distribution")
-	ErrInvalidParams       = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid params")
-	ErrInvalidGenesis      = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid genesis")
-	ErrInvalidVote         = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid vote")
-	ErrInvalidVoterInfo    = errorsmod.Wrap(gerrc.ErrInvalidArgument, "invalid voter info")
-	ErrNoEndorsers         = errorsmod.Wrap(gerrc.ErrFailedPrecondition, "no endorsers")
+	ErrInvalidGaugeWeight  = errorsmod.RegisterWithGRPCCode(ModuleName, 1, codes.InvalidArgument, "invalid gauge weight")
+	ErrInvalidDistribution = errorsmod.RegisterWithGRPCCode(ModuleName, 2, codes.InvalidArgument, "invalid gauge weight distribution")
+	ErrInvalidParams       = errorsmod.RegisterWithGRPCCode(ModuleName, 3, codes.InvalidArgument, "invalid params")
+	ErrInvalidGenesis      = errorsmod.RegisterWithGRPCCode(ModuleName, 4, codes.InvalidArgument, "invalid genesis")
+	ErrInvalidVote         = errorsmod.RegisterWithGRPCCode(ModuleName, 5, codes.InvalidArgument, "invalid vote")
+	ErrInvalidVoterInfo    = errorsmod.RegisterWithGRPCCode(ModuleName, 6, codes.InvalidArgument, "invalid voter info")
+	ErrNoEndorsers         = errorsmod.RegisterWithGRPCCode(ModuleName, 7, codes.FailedPrecondition, "no endorsers")
 )

--- a/x/sponsorship/types/errors_test.go
+++ b/x/sponsorship/types/errors_test.go
@@ -1,0 +1,32 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dymensionxyz/dymension/v3/x/sponsorship/types"
+)
+
+func TestErrorsUseGerrcCategories(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		category error
+	}{
+		{name: "invalid gauge weight", err: types.ErrInvalidGaugeWeight, category: gerrc.ErrInvalidArgument},
+		{name: "invalid distribution", err: types.ErrInvalidDistribution, category: gerrc.ErrInvalidArgument},
+		{name: "invalid params", err: types.ErrInvalidParams, category: gerrc.ErrInvalidArgument},
+		{name: "invalid genesis", err: types.ErrInvalidGenesis, category: gerrc.ErrInvalidArgument},
+		{name: "invalid vote", err: types.ErrInvalidVote, category: gerrc.ErrInvalidArgument},
+		{name: "invalid voter info", err: types.ErrInvalidVoterInfo, category: gerrc.ErrInvalidArgument},
+		{name: "no endorsers", err: types.ErrNoEndorsers, category: gerrc.ErrFailedPrecondition},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.err, tt.category)
+		})
+	}
+}

--- a/x/sponsorship/types/errors_test.go
+++ b/x/sponsorship/types/errors_test.go
@@ -1,32 +1,44 @@
 package types_test
 
 import (
+	"errors"
 	"testing"
 
+	errorsmod "cosmossdk.io/errors"
 	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dymensionxyz/dymension/v3/x/sponsorship/types"
 )
 
-func TestErrorsUseGerrcCategories(t *testing.T) {
-	tests := []struct {
-		name     string
-		err      error
-		category error
-	}{
-		{name: "invalid gauge weight", err: types.ErrInvalidGaugeWeight, category: gerrc.ErrInvalidArgument},
-		{name: "invalid distribution", err: types.ErrInvalidDistribution, category: gerrc.ErrInvalidArgument},
-		{name: "invalid params", err: types.ErrInvalidParams, category: gerrc.ErrInvalidArgument},
-		{name: "invalid genesis", err: types.ErrInvalidGenesis, category: gerrc.ErrInvalidArgument},
-		{name: "invalid vote", err: types.ErrInvalidVote, category: gerrc.ErrInvalidArgument},
-		{name: "invalid voter info", err: types.ErrInvalidVoterInfo, category: gerrc.ErrInvalidArgument},
-		{name: "no endorsers", err: types.ErrNoEndorsers, category: gerrc.ErrFailedPrecondition},
+func TestErrorsHaveDistinctIdentitiesAndGRPCCategories(t *testing.T) {
+	invalidErrors := []error{
+		types.ErrInvalidGaugeWeight,
+		types.ErrInvalidDistribution,
+		types.ErrInvalidParams,
+		types.ErrInvalidGenesis,
+		types.ErrInvalidVote,
+		types.ErrInvalidVoterInfo,
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.ErrorIs(t, tt.err, tt.category)
-		})
+	for i, err := range invalidErrors {
+		codespace, code, _ := errorsmod.ABCIInfo(err, false)
+		require.Equal(t, types.ModuleName, codespace)
+		require.Equal(t, uint32(i+1), code)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		for j, other := range invalidErrors {
+			if i != j {
+				require.False(t, errors.Is(err, other), "%v must not match %v", err, other)
+			}
+		}
 	}
+
+	codespace, code, _ := errorsmod.ABCIInfo(types.ErrNoEndorsers, false)
+	require.Equal(t, types.ModuleName, codespace)
+	require.Equal(t, uint32(7), code)
+	require.Equal(t, codes.FailedPrecondition, status.Code(types.ErrNoEndorsers))
+	require.False(t, errors.Is(gerrc.ErrFailedPrecondition.Wrap("anything"), types.ErrNoEndorsers))
 }

--- a/x/sponsorship/types/genesis.go
+++ b/x/sponsorship/types/genesis.go
@@ -25,7 +25,7 @@ func (g GenesisState) Validate() error {
 	for _, i := range g.VoterInfos {
 		// validate all voters are unique
 		if _, ok := voters[i.Voter]; ok {
-			return ErrInvalidGenesis.Wrapf("duplicated voters: %s", i.Voter)
+			return errorsmod.Wrapf(ErrInvalidGenesis, "duplicated voters: %s", i.Voter)
 		}
 		voters[i.Voter] = struct{}{}
 
@@ -57,13 +57,13 @@ func (v VoterInfo) Validate() error {
 	validators := make(map[string]struct{}, len(v.Validators)) // this map helps check for duplicates
 	for _, val := range v.Validators {
 		if _, ok := validators[val.Validator]; ok {
-			return ErrInvalidVoterInfo.Wrapf("duplicated validators: %s", val.Validator)
+			return errorsmod.Wrapf(ErrInvalidVoterInfo, "duplicated validators: %s", val.Validator)
 		}
 		validators[val.Validator] = struct{}{}
 		total = total.Add(val.Power)
 	}
 	if total.GT(v.Vote.VotingPower) {
-		return ErrInvalidVoterInfo.Wrapf("voting power mismatch: vote voting power %s is less than total validator power %s", v.Vote.VotingPower, total)
+		return errorsmod.Wrapf(ErrInvalidVoterInfo, "voting power mismatch: vote voting power %s is less than total validator power %s", v.Vote.VotingPower, total)
 	}
 
 	return nil

--- a/x/sponsorship/types/msgs.go
+++ b/x/sponsorship/types/msgs.go
@@ -1,8 +1,9 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 var (
@@ -15,7 +16,7 @@ var (
 func (m MsgVote) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.Voter)
 	if err != nil {
-		return sdkerrors.ErrInvalidAddress.Wrapf(
+		return gerrc.ErrInvalidArgument.Wrapf(
 			"voter '%s' must be a valid bech32 address: %s",
 			m.Voter, err.Error(),
 		)
@@ -23,7 +24,7 @@ func (m MsgVote) ValidateBasic() error {
 
 	err = ValidateGaugeWeights(m.Weights)
 	if err != nil {
-		return ErrInvalidDistribution.Wrap(err.Error())
+		return errorsmod.Wrap(ErrInvalidDistribution, err.Error())
 	}
 
 	return nil
@@ -32,7 +33,7 @@ func (m MsgVote) ValidateBasic() error {
 func (m MsgRevokeVote) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.Voter)
 	if err != nil {
-		return sdkerrors.ErrInvalidAddress.Wrapf(
+		return gerrc.ErrInvalidArgument.Wrapf(
 			"voter '%s' must be a valid bech32 address: %s",
 			m.Voter, err.Error(),
 		)
@@ -43,7 +44,7 @@ func (m MsgRevokeVote) ValidateBasic() error {
 func (m MsgUpdateParams) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.Authority)
 	if err != nil {
-		return sdkerrors.ErrInvalidAddress.Wrapf(
+		return gerrc.ErrInvalidArgument.Wrapf(
 			"authority '%s' must be a valid bech32 address: %s",
 			m.Authority, err.Error(),
 		)
@@ -51,7 +52,7 @@ func (m MsgUpdateParams) ValidateBasic() error {
 
 	err = m.NewParams.ValidateBasic()
 	if err != nil {
-		return ErrInvalidParams.Wrap(err.Error())
+		return errorsmod.Wrap(ErrInvalidParams, err.Error())
 	}
 
 	return nil
@@ -60,7 +61,7 @@ func (m MsgUpdateParams) ValidateBasic() error {
 func (m MsgClaimRewards) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(m.Sender)
 	if err != nil {
-		return sdkerrors.ErrInvalidAddress.Wrapf(
+		return gerrc.ErrInvalidArgument.Wrapf(
 			"sender '%s' must be a valid bech32 address: %s",
 			m.Sender, err.Error(),
 		)

--- a/x/sponsorship/types/msgs_test.go
+++ b/x/sponsorship/types/msgs_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dymensionxyz/dymension/v3/app/apptesting"
@@ -43,7 +43,7 @@ func TestMsgVote(t *testing.T) {
 					{GaugeId: 12, Weight: math.NewInt(10)},
 				},
 			},
-			errorIs:       sdkerrors.ErrInvalidAddress,
+			errorIs:       gerrc.ErrInvalidArgument,
 			errorContains: "voter '123123' must be a valid bech32 address",
 		},
 		{
@@ -100,7 +100,7 @@ func TestMsgRevokeVote(t *testing.T) {
 			input: types.MsgRevokeVote{
 				Voter: "123123",
 			},
-			errorIs:       sdkerrors.ErrInvalidAddress,
+			errorIs:       gerrc.ErrInvalidArgument,
 			errorContains: "voter '123123' must be a valid bech32 address",
 		},
 	}
@@ -146,7 +146,7 @@ func TestMsgUpdateParams(t *testing.T) {
 				Authority: "123123",
 				NewParams: types.DefaultParams(),
 			},
-			errorIs:       sdkerrors.ErrInvalidAddress,
+			errorIs:       gerrc.ErrInvalidArgument,
 			errorContains: "authority '123123' must be a valid bech32 address",
 		},
 		{

--- a/x/sponsorship/types/params.go
+++ b/x/sponsorship/types/params.go
@@ -1,5 +1,7 @@
 package types
 
+import errorsmod "cosmossdk.io/errors"
+
 func DefaultParams() Params {
 	return Params{
 		MinAllocationWeight: DefaultMinAllocationWeight,
@@ -9,13 +11,13 @@ func DefaultParams() Params {
 
 func (p Params) ValidateBasic() error {
 	if p.MinAllocationWeight.IsNegative() {
-		return ErrInvalidParams.Wrapf("MinAllocationWeight must be >= 0, got %s", p.MinAllocationWeight)
+		return errorsmod.Wrapf(ErrInvalidParams, "MinAllocationWeight must be >= 0, got %s", p.MinAllocationWeight)
 	}
 	if p.MinAllocationWeight.GT(MaxAllocationWeight) {
-		return ErrInvalidParams.Wrapf("MinAllocationWeight must be <= 100 * 10^18, got %s", p.MinAllocationWeight)
+		return errorsmod.Wrapf(ErrInvalidParams, "MinAllocationWeight must be <= 100 * 10^18, got %s", p.MinAllocationWeight)
 	}
 	if p.MinVotingPower.IsNegative() {
-		return ErrInvalidParams.Wrapf("MinVotingPower must be >= 0, got %s", p.MinVotingPower)
+		return errorsmod.Wrapf(ErrInvalidParams, "MinVotingPower must be >= 0, got %s", p.MinVotingPower)
 	}
 	return nil
 }

--- a/x/sponsorship/types/types.go
+++ b/x/sponsorship/types/types.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"sort"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -13,19 +14,19 @@ func (d Distribution) Validate() error {
 	gaugeIDs := make(map[uint64]struct{}, len(d.Gauges)) // this map helps check for duplicates
 	for _, g := range d.Gauges {
 		if _, ok := gaugeIDs[g.GaugeId]; ok {
-			return ErrInvalidDistribution.Wrapf("duplicated gauge id: %d", g.GaugeId)
+			return errorsmod.Wrapf(ErrInvalidDistribution, "duplicated gauge id: %d", g.GaugeId)
 		}
 		gaugeIDs[g.GaugeId] = struct{}{}
 		if !g.Power.IsPositive() { // zeros are already pruned
-			return ErrInvalidDistribution.Wrapf("gauge power must be > 0, got %s: id: %d", g.Power, g.GaugeId)
+			return errorsmod.Wrapf(ErrInvalidDistribution, "gauge power must be > 0, got %s: id: %d", g.Power, g.GaugeId)
 		}
 		total = total.Add(g.Power)
 	}
 	if total.GT(d.VotingPower) {
-		return ErrInvalidDistribution.Wrapf("voting power mismatch: sum of gauge powers %s is greater than the total voting power %s", total, d.VotingPower)
+		return errorsmod.Wrapf(ErrInvalidDistribution, "voting power mismatch: sum of gauge powers %s is greater than the total voting power %s", total, d.VotingPower)
 	}
 	if d.VotingPower.IsNegative() {
-		return ErrInvalidDistribution.Wrapf("voting power must be >= 0, got %s", d.VotingPower)
+		return errorsmod.Wrapf(ErrInvalidDistribution, "voting power must be >= 0, got %s", d.VotingPower)
 	}
 	return nil
 }
@@ -33,10 +34,10 @@ func (d Distribution) Validate() error {
 func (v Vote) Validate() error {
 	err := ValidateGaugeWeights(v.Weights)
 	if err != nil {
-		return ErrInvalidVote.Wrap(err.Error())
+		return errorsmod.Wrap(ErrInvalidVote, err.Error())
 	}
 	if !v.VotingPower.IsPositive() {
-		return ErrInvalidVote.Wrapf("must be > 0, got %s", v.VotingPower)
+		return errorsmod.Wrapf(ErrInvalidVote, "must be > 0, got %s", v.VotingPower)
 	}
 	return nil
 }
@@ -59,26 +60,26 @@ func ValidateGaugeWeights(w []GaugeWeight) error {
 	for _, g := range w {
 		err := g.Validate()
 		if err != nil {
-			return ErrInvalidGaugeWeight.Wrap(err.Error())
+			return errorsmod.Wrap(ErrInvalidGaugeWeight, err.Error())
 		}
 		if _, ok := gaugeIDs[g.GaugeId]; ok {
-			return ErrInvalidGaugeWeight.Wrapf("duplicated gauge id: %d", g.GaugeId)
+			return errorsmod.Wrapf(ErrInvalidGaugeWeight, "duplicated gauge id: %d", g.GaugeId)
 		}
 		gaugeIDs[g.GaugeId] = struct{}{}
 		total = total.Add(g.Weight)
 	}
 	if total.GT(MaxAllocationWeight) {
-		return ErrInvalidGaugeWeight.Wrapf("total weight must be less than 100 * 10^18, got %s", total)
+		return errorsmod.Wrapf(ErrInvalidGaugeWeight, "total weight must be less than 100 * 10^18, got %s", total)
 	}
 	return nil
 }
 
 func (g GaugeWeight) Validate() error {
 	if !g.Weight.IsPositive() {
-		return ErrInvalidGaugeWeight.Wrapf("weight must be > 0, got %s", g.Weight)
+		return errorsmod.Wrapf(ErrInvalidGaugeWeight, "weight must be > 0, got %s", g.Weight)
 	}
 	if g.Weight.GT(MaxAllocationWeight) {
-		return ErrInvalidGaugeWeight.Wrapf("weight must be <= 100 * 10^18, got %s", g.Weight)
+		return errorsmod.Wrapf(ErrInvalidGaugeWeight, "weight must be <= 100 * 10^18, got %s", g.Weight)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #1077

`x/sponsorship` used legacy Cosmos SDK errors and uncategorized user-facing failures. This change assigns semantic gRPC categories to the module's distinct registered sentinels and uses direct `gerrc` cause chains at query and keeper boundaries, leaving state-machine behavior unchanged.

- Keeps all seven exported sponsorship sentinels mutually distinguishable.
- Assigns `InvalidArgument` or `FailedPrecondition` gRPC status to each sentinel.
- Classifies address, authority, gauge, voting-power, and missing-query errors.
- Adds ABCI codespace/code and negative `errors.Is` regression coverage.

<details><summary>Error taxonomy</summary>

- Invalid messages, params, genesis data, votes, distributions, and gauge shapes use `InvalidArgument` semantics.
- Missing gauges, votes, endorsements, and claim inputs resolve to `gerrc.ErrNotFound` (`gerrc` code 4).
- Minimum voting power, minimum allocation, and absent endorsers use `FailedPrecondition` semantics.
- Governance authority mismatches use `gerrc.ErrUnauthenticated`.
- Gauge decode/corruption errors retain their original cause and are not mislabeled `NotFound`.

</details>

<details><summary>Behavior and compatibility</summary>

Exported sponsorship sentinel names and their distinct `errors.Is` identities remain intact, including the `ErrNoEndorsers` control-flow contract used by `x/incentives`. Their registered errors now carry explicit gRPC status codes. Direct query and keeper classifications retain a `gerrc` root in the `Cause()` chain so `ABCIInfo` and `GRPCStatus` resolve correctly; storage writes, events, and state transitions are untouched.

</details>

## Proof of execution

- Build and Test CI suite — initial full-gate `go build ./...` and `go test -race ./...`: passed locally, including `x/sponsorship/keeper` and `x/sponsorship/types`.
- golangci-lint CI suite — CI-pinned v2.1 initial full gate and fix-round `golangci-lint run ./x/sponsorship/...`: passed locally with `0 issues`.
- Sponsorship fix-round regression suite — `go test ./x/sponsorship/... -count=1`: passed all packages, including sentinel identity and ABCI codespace/code assertions.

**Not verified:** nothing; all changed behaviors are covered by the suites above.
