### PR TITLE
fix(rollapp): handle missing revision heights

### DIFF
--- a/x/rollapp/keeper/fraud_proposal.go
+++ b/x/rollapp/keeper/fraud_proposal.go
@@ -37,8 +37,14 @@ func (k Keeper) SubmitRollappFraud(goCtx context.Context, msg *types.MsgRollappF
 	}
 
 	// check correct revision number (to avoid sending duplicated proposals)
-	if rollapp.GetRevisionForHeight(msg.FraudHeight).Number != msg.FraudRevision {
-		err := errorsmod.Wrapf(gerrc.ErrFailedPrecondition, "fraud revision number mismatch: %d != %d", rollapp.GetRevisionForHeight(msg.FraudHeight).Number, msg.FraudRevision)
+	revision, found := rollapp.GetRevisionForHeight(msg.FraudHeight)
+	if !found {
+		err := errorsmod.Wrapf(gerrc.ErrFailedPrecondition, "revision not found for fraud height: %d", msg.FraudHeight)
+		ctx.Logger().Error("Fraud proposal", "error", err)
+		return nil, err
+	}
+	if revision.Number != msg.FraudRevision {
+		err := errorsmod.Wrapf(gerrc.ErrFailedPrecondition, "fraud revision number mismatch: %d != %d", revision.Number, msg.FraudRevision)
 		ctx.Logger().Error("Fraud proposal", "error", err)
 		return nil, err
 	}

--- a/x/rollapp/keeper/fraud_proposal_test.go
+++ b/x/rollapp/keeper/fraud_proposal_test.go
@@ -1,8 +1,10 @@
 package keeper_test
 
 import (
+	"cosmossdk.io/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/dymensionxyz/dymension/v3/x/rollapp/types"
+	"github.com/dymensionxyz/gerr-cosmos/gerrc"
 )
 
 // TODO: test slashing and Rewardee
@@ -12,10 +14,11 @@ func (s *RollappTestSuite) TestSubmitRollappFraud() {
 	initialHeight := uint64(1)
 
 	testCases := []struct {
-		name          string
-		msgRevision   uint64
-		msgHeight     uint64
-		expectedError bool
+		name            string
+		msgRevision     uint64
+		msgHeight       uint64
+		expectedError   bool
+		removeRevisions bool
 	}{
 		{
 			name:          "first revision proposal",
@@ -40,6 +43,13 @@ func (s *RollappTestSuite) TestSubmitRollappFraud() {
 			msgRevision:   5,
 			msgHeight:     300,
 			expectedError: true,
+		},
+		{
+			name:            "height without revision",
+			msgRevision:     0,
+			msgHeight:       40,
+			expectedError:   true,
+			removeRevisions: true,
 		},
 	}
 
@@ -86,12 +96,16 @@ func (s *RollappTestSuite) TestSubmitRollappFraud() {
 
 			// assert revision correctness
 			rollapp = s.k().MustGetRollapp(s.Ctx, rollappId)
-			s.Require().EqualValues(rollapp.GetRevisionForHeight(1).Number, 0)
-			s.Require().EqualValues(rollapp.GetRevisionForHeight(49).Number, 0)
-			s.Require().EqualValues(rollapp.GetRevisionForHeight(50).Number, 1)
-			s.Require().EqualValues(rollapp.GetRevisionForHeight(55).Number, 1)
-			s.Require().EqualValues(rollapp.GetRevisionForHeight(120).Number, 2)
-			s.Require().EqualValues(rollapp.GetRevisionForHeight(300).Number, 2)
+			for height, expectedRevision := range map[uint64]uint64{1: 0, 49: 0, 50: 1, 55: 1, 120: 2, 300: 2} {
+				revision, found := rollapp.GetRevisionForHeight(height)
+				s.Require().True(found)
+				s.Require().EqualValues(expectedRevision, revision.Number)
+			}
+
+			if tc.removeRevisions {
+				rollapp.Revisions = nil
+				s.k().SetRollapp(s.Ctx, rollapp)
+			}
 
 			msg := &types.MsgRollappFraudProposal{
 				Authority:              s.App.AccountKeeper.GetModuleAddress(govtypes.ModuleName).String(),
@@ -108,6 +122,9 @@ func (s *RollappTestSuite) TestSubmitRollappFraud() {
 				s.Require().NoError(err)
 			} else {
 				s.Require().Error(err)
+				if tc.removeRevisions {
+					s.Require().True(errors.IsOf(err, gerrc.ErrFailedPrecondition))
+				}
 			}
 		})
 	}

--- a/x/rollapp/types/rollapp.go
+++ b/x/rollapp/types/rollapp.go
@@ -140,19 +140,18 @@ func (r Rollapp) LatestRevision() Revision {
 	return r.Revisions[len(r.Revisions)-1]
 }
 
-// TODO: rollapp type method should be more robust https://github.com/dymensionxyz/dymension/issues/1596
-func (r Rollapp) GetRevisionForHeight(h uint64) Revision {
+func (r Rollapp) GetRevisionForHeight(h uint64) (Revision, bool) {
 	for i := len(r.Revisions) - 1; i >= 0; i-- {
 		if r.Revisions[i].StartHeight <= h {
-			return r.Revisions[i]
+			return r.Revisions[i], true
 		}
 	}
-	return Revision{}
+	return Revision{}, false
 }
 
 func (r Rollapp) IsRevisionStartHeight(revision, height uint64) bool {
-	rev := r.GetRevisionForHeight(height)
-	return rev.Number == revision && rev.StartHeight == height
+	rev, found := r.GetRevisionForHeight(height)
+	return found && rev.Number == revision && rev.StartHeight == height
 }
 
 func (r Rollapp) DidFork() bool {

--- a/x/rollapp/types/rollapp_test.go
+++ b/x/rollapp/types/rollapp_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRollappGetRevisionForHeight(t *testing.T) {
+	rollapp := Rollapp{Revisions: []Revision{{Number: 1, StartHeight: 10}}}
+
+	revision, found := rollapp.GetRevisionForHeight(9)
+	require.False(t, found)
+	require.Equal(t, Revision{}, revision)
+	require.False(t, rollapp.IsRevisionStartHeight(0, 0))
+
+	revision, found = rollapp.GetRevisionForHeight(10)
+	require.True(t, found)
+	require.Equal(t, Revision{Number: 1, StartHeight: 10}, revision)
+	require.True(t, rollapp.IsRevisionStartHeight(1, 10))
+}


### PR DESCRIPTION
Closes #1596

`GetRevisionForHeight` previously returned a zero-value revision when no revision covered a height, making missing state indistinguishable from a valid genesis revision. This change returns an explicit found boolean, rejects missing fraud-height revisions before mutation, and keeps valid lookup behavior unchanged.

- Makes missing revision heights explicit.
- Rejects malformed-state fraud proposals with `ErrFailedPrecondition`.
- Covers valid, below-first, and empty revision lists.

<details><summary>Implementation details</summary>

- Changes `Rollapp.GetRevisionForHeight` to return `(Revision, bool)`.
- Makes `IsRevisionStartHeight` return false when no revision covers the height.
- Performs one revision lookup in `SubmitRollappFraud` and exits before `HardFork` when it is missing.
- Removes the resolved issue TODO.

</details>

## Proof of execution

- Targeted rollapp regression suites: PASS — `go test ./x/rollapp/types ./x/rollapp/keeper -run "TestRollappGetRevisionForHeight|TestRollappKeeperTestSuite/TestSubmitRollappFraud" -count=1 -v`.
- Build and Test / race coverage equivalent: PASS — `go-acc -o /tmp/issue1596-coverage.txt ./... -- -race`; changed packages `x/rollapp/keeper` and `x/rollapp/types` passed.
- Full repository tests: PASS — `go test ./... -count=1`.
- Build and vet: PASS — `go build ./...` and `go vet ./...`.
- GitHub Build and Test (`build`): PASS.
- GitHub CodeQL (`Analyze`, `CodeQL`): PASS.
- GitHub `golangci-lint`: PASS on rerun; the first attempt timed out fetching the upstream lint schema before analysis began.
- GitHub codecov (`codecov/patch`, `codecov/project`): PASS.
- Independent Go review: PASS — no actionable findings.

**Not verified:** nothing; all changed behaviors are covered by automated tests.