### PR TITLE
test(rollapp): pin create-rollapp gas determinism

### DIFF
--- a/x/rollapp/keeper/msg_server_create_rollapp_gas_test.go
+++ b/x/rollapp/keeper/msg_server_create_rollapp_gas_test.go
@@ -1,0 +1,176 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/evmos/ethermint/crypto/ethsecp256k1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dymensionxyz/dymension/v3/app"
+	"github.com/dymensionxyz/dymension/v3/app/apptesting"
+	"github.com/dymensionxyz/dymension/v3/x/rollapp/types"
+)
+
+// Gas for a tx must be a pure function of the tx bytes and the committed state.
+// Simulating one unchanged MsgCreateRollapp against one unchanged committed state
+// must therefore return the same figure every time, and delivering it on two
+// independently built chains must agree.
+const createRollappGasRuns = 20
+
+func TestCreateRollappGasIsDeterministic(t *testing.T) {
+	t.Run("simulate", func(t *testing.T) {
+		a, txBytes := setupCreateRollappGasFixture(t)
+
+		gas := make([]uint64, createRollappGasRuns)
+		for i := range gas {
+			info, res, err := a.Simulate(txBytes)
+			require.NoError(t, err)
+			require.NotNil(t, res, "run %d: simulation returned no result", i)
+			gas[i] = info.GasUsed
+		}
+
+		for i, g := range gas {
+			require.Equal(t, gas[0], g, "run %d consumed %d gas, first run consumed %d (all runs: %v)", i, g, gas[0], gas)
+		}
+		t.Logf("%d simulations against identical committed state: %d gas each", createRollappGasRuns, gas[0])
+
+		// A simulation must not leave anything behind, or the next one would price differently.
+		check := a.NewContextLegacy(true, cmtproto.Header{Height: 1, ChainID: apptesting.TestChainID})
+		_, found := a.RollappKeeper.GetRollapp(check, createRollappGasRollappID)
+		require.False(t, found, "simulation leaked the rollapp into the check state")
+		require.Zero(t, a.AccountKeeper.GetAccount(check, createRollappGasCreator()).GetSequence(),
+			"simulation leaked the signer's sequence increment into the check state")
+	})
+
+	t.Run("deliver", func(t *testing.T) {
+		a1, txBytes1 := setupCreateRollappGasFixture(t)
+		a2, txBytes2 := setupCreateRollappGasFixture(t)
+		require.Equal(t, txBytes1, txBytes2, "fixtures must produce byte-identical txs to be comparable")
+
+		require.Equal(t, deliverCreateRollapp(t, a1, txBytes1), deliverCreateRollapp(t, a2, txBytes2))
+	})
+
+	// Guards the assertions above against passing vacuously: the measurement has to
+	// move when the tx does.
+	t.Run("gas tracks the payload", func(t *testing.T) {
+		a, txBytes := setupCreateRollappGasFixture(t)
+		base, _, err := a.Simulate(txBytes)
+		require.NoError(t, err)
+
+		check := a.NewContextLegacy(true, cmtproto.Header{Height: 1, ChainID: apptesting.TestChainID})
+		acc := a.AccountKeeper.GetAccount(check, createRollappGasCreator())
+		larger := signTx(t, a.TxConfig(), createRollappGasMsg("1234567890abcdefg1234567890abcdefg1234567890abcdefg"),
+			createRollappGasPrivKey(), acc.GetAccountNumber(), acc.GetSequence())
+
+		got, _, err := a.Simulate(larger)
+		require.NoError(t, err)
+		require.NotEqual(t, base.GasUsed, got.GasUsed)
+	})
+}
+
+func deliverCreateRollapp(t *testing.T, a *app.App, txBytes []byte) uint64 {
+	t.Helper()
+
+	res, err := a.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 2, Txs: [][]byte{txBytes}})
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), res.TxResults[0].Code, res.TxResults[0].Log)
+	return uint64(res.TxResults[0].GasUsed)
+}
+
+const (
+	createRollappGasRollappID = "rollappevm_1234-1"
+	createRollappGasAlias     = "icxuv"
+)
+
+func createRollappGasPrivKey() *ethsecp256k1.PrivKey {
+	priv := &ethsecp256k1.PrivKey{Key: make([]byte, 32)}
+	priv.Key[31] = 1
+	return priv
+}
+
+func createRollappGasCreator() sdk.AccAddress {
+	return sdk.AccAddress(createRollappGasPrivKey().PubKey().Address())
+}
+
+func createRollappGasMsg(genesisChecksum string) *types.MsgCreateRollapp {
+	return &types.MsgCreateRollapp{
+		Creator:          createRollappGasCreator().String(),
+		RollappId:        createRollappGasRollappID,
+		InitialSequencer: "*",
+		MinSequencerBond: types.DefaultMinSequencerBondGlobalCoin,
+		Alias:            createRollappGasAlias,
+		VmType:           types.Rollapp_EVM,
+		GenesisInfo: &types.GenesisInfo{
+			Bech32Prefix:    "ethm",
+			GenesisChecksum: genesisChecksum,
+			InitialSupply:   math.NewInt(1000),
+			NativeDenom: types.DenomMetadata{
+				Display:  "RAX",
+				Base:     "urax",
+				Exponent: 18,
+			},
+		},
+	}
+}
+
+// setupCreateRollappGasFixture returns a chain whose state is committed, plus a signed
+// MsgCreateRollapp tx ready to be simulated or delivered against that state.
+func setupCreateRollappGasFixture(t *testing.T) (*app.App, []byte) {
+	t.Helper()
+
+	a := apptesting.Setup(t)
+	ctx := a.NewContextLegacy(false, cmtproto.Header{Height: 1, ChainID: apptesting.TestChainID})
+
+	msg := createRollappGasMsg("1234567890abcdefg")
+	apptesting.FundForAliasRegistration(a, ctx, msg.Alias, msg.Creator)
+
+	_, err := a.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 1})
+	require.NoError(t, err)
+	_, err = a.Commit()
+	require.NoError(t, err)
+
+	committed := a.NewContextLegacy(true, cmtproto.Header{Height: 1, ChainID: apptesting.TestChainID})
+	acc := a.AccountKeeper.GetAccount(committed, createRollappGasCreator())
+	require.NotNil(t, acc)
+
+	return a, signTx(t, a.TxConfig(), msg, createRollappGasPrivKey(), acc.GetAccountNumber(), acc.GetSequence())
+}
+
+func signTx(t *testing.T, txConfig client.TxConfig, msg sdk.Msg, priv cryptotypes.PrivKey, accNum, seq uint64) []byte {
+	t.Helper()
+
+	b := txConfig.NewTxBuilder()
+	require.NoError(t, b.SetMsgs(msg))
+	b.SetGasLimit(200000)
+
+	sigData := &signingtypes.SingleSignatureData{SignMode: signingtypes.SignMode_SIGN_MODE_DIRECT}
+	sig := signingtypes.SignatureV2{PubKey: priv.PubKey(), Data: sigData, Sequence: seq}
+	require.NoError(t, b.SetSignatures(sig))
+
+	signBytes, err := authsigning.GetSignBytesAdapter(
+		t.Context(), txConfig.SignModeHandler(), signingtypes.SignMode_SIGN_MODE_DIRECT,
+		authsigning.SignerData{
+			Address:       sdk.AccAddress(priv.PubKey().Address()).String(),
+			ChainID:       apptesting.TestChainID,
+			AccountNumber: accNum,
+			Sequence:      seq,
+			PubKey:        priv.PubKey(),
+		}, b.GetTx())
+	require.NoError(t, err)
+
+	sigData.Signature, err = priv.Sign(signBytes)
+	require.NoError(t, err)
+	require.NoError(t, b.SetSignatures(sig))
+
+	txBytes, err := txConfig.TxEncoder()(b.GetTx())
+	require.NoError(t, err)
+	return txBytes
+}


### PR DESCRIPTION
Closes #1304

**No gas non-determinism reproduces at HEAD, and the reported failure is fully explained.** The issue reported a `create-rollapp` tx dying with `out of gas` at the CLI's default 200000 limit while an immediate retry succeeded, plus repeated `--dry-run` calls returning two different estimates. This PR lands a regression test that simulates one unchanged `MsgCreateRollapp` twenty times against one unchanged committed state and asserts every run returns the same figure — it does, at 194567 gas, in every one of 15 independent processes. The out-of-gas failure was the default gas limit meeting a first-ever tx from that account: persisting the signer's pubkey on first use costs measurably extra gas, which is exactly why the sequence-0 attempt exceeded 200000 and the sequence-1 retry fit under it. `--gas auto` is the correct usage.

<details>
<summary>What the test pins, and why it is shaped this way</summary>

The invariant is that gas must be a pure function of the tx bytes and the committed state. `TestCreateRollappGasIsDeterministic` has three parts:

- **simulate** — builds a chain, commits its state, then simulates one signed `MsgCreateRollapp` twenty times back to back without committing anything in between, and requires all twenty gas figures to be equal. Running the simulations back to back rather than resetting between them is deliberate: it is what a user hitting `--dry-run` repeatedly does, and it is the arrangement in which any leakage from one simulation into the next would show up. The subtest then asserts directly that nothing leaked — the rollapp is absent from the check state and the signer's sequence is still zero.
- **deliver** — the invariant is pinned for the consensus-critical path too, not just simulation. Two independently constructed chains each deliver the byte-identical tx in a real block and must report the same `GasUsed`. The two chains are built with independently randomized genesis validator and account keys, so this also catches gas that depends on anything other than committed state shape.
- **gas tracks the payload** — a control, so the twenty equal numbers cannot pass vacuously. An otherwise identical message carrying a longer genesis checksum must produce a *different* figure. Without this, a test asserting "all runs equal" would still pass if the message silently stopped executing.

</details>

<details>
<summary>Why the historical failure happened</summary>

Two separate things were folded into the issue.

The **out-of-gas failure** is not a bug. The cosmos-sdk CLI defaults to `--gas 200000`, and `create-rollapp` on that chain consumed roughly 197k–200.6k. The first tx an account ever sends costs materially more than its successors, because the ante handler persists the signer's pubkey onto the account the first time it is seen. In the issue that shows as 200595 gas at sequence 0 (which busted the 200000 limit) against 197088 at sequence 1 (which did not) — a 3507 gas gap between two otherwise identical messages. I measured the same effect at HEAD in a controlled experiment where the *only* difference was whether the pubkey was already on the account: 194567 versus 180994, a 13573 gas gap. The magnitude differs from the 2024 chain, as expected given different state and a different SDK, but the mechanism and its sign are the same. This is why `--gas auto` fixes it and why the retry appeared to "just work".

The **two differing `--dry-run` estimates** do not reproduce at HEAD. I ruled out the obvious candidate rather than assuming it: the hypothesis that a simulation leaves its ante-handler writes behind in the check state, so that the next simulation prices against mutated state. That is not what happens, and it is not what happened in 2024 either — the repo ran cosmos-sdk v0.47.13 when the issue was filed, and v0.47.13 wraps simulation in a discarded cache context exactly as v0.50.14 does, so simulations were isolated from each other then as well.

What remains is that those estimates were taken against a live chain that kept producing blocks between the calls, so they were not taken against the same committed state. Gas legitimately tracks committed state, so two estimates at two heights are not by themselves a determinism defect. I could not confirm the specific 2024 mechanism — that migration testnet is gone and the platform has moved on — so I am not claiming to have identified it. What is now pinned in CI is the property that actually matters and that would have caught a real defect: same tx, same committed state, same gas.

</details>

<details>
<summary>Scope</summary>

Test-only. No production code changes, so nothing here is consensus-breaking and no upgrade handler is involved. No proto changes.

</details>

## Proof of execution

- **Regression test passes** — `TestCreateRollappGasIsDeterministic` (simulate / deliver / gas tracks the payload) in `x/rollapp/keeper`. Re-run by the **Build and Test** CI workflow.
- **Whole repository test suite, race-enabled, green** — `go test -race ./...`, matching what **Build and Test** runs via `go-acc ... -- -v --race`. Two packages needed a longer `-timeout` than Go's 10-minute default to finish on a contended machine; both pass. Detail below.
- **Lint clean** — re-run by the **golangci-lint** CI workflow.
- **Build green** — `go build ./...`, re-run by **Build and Test**.
- Determinism holds across 15 independent processes, not just 20 runs in one — evidence below (CI runs the suite once, so this is not CI-covered).
- The first-use pubkey cost is real and measured in a controlled experiment — evidence below.
- Simulation isolation is identical in cosmos-sdk v0.47.13 and v0.50.14, ruling out leakage as the historical cause — evidence below.
- The three `golangci-lint` findings that remain in `x/rollapp` are pre-existing — reproduced on the merge base, evidence below.

<details>
<summary>Full race suite: 62 packages green, and the two that needed more time</summary>

`go test -race ./...` over the whole repository reported 62 packages `ok`, 48 with no test files, and two packages that hit Go's default 10-minute per-package timeout — `ibctesting` at 600.6s and `x/iro/types` at 601.4s. Both ended in `panic: test timed out after 10m0s`, not in a failed assertion, and another agent was running `go test -race ./...` concurrently on the same 12-core machine throughout.

Neither package links this PR's file: a `_test.go` in `x/rollapp/keeper` is compiled only into that package's test binary, so it cannot affect them. Re-running just those two with an adequate timeout confirms there is no failure to attribute:

```
$ go test -race -timeout 50m ./ibctesting/... ./x/iro/types/...
ok  	github.com/dymensionxyz/dymension/v3/ibctesting	82.582s
ok  	github.com/dymensionxyz/dymension/v3/x/iro/types	406.477s
exit 0
```

`ibctesting` finishing in 82s once uncontended shows how badly it was starved. `x/iro/types` takes 406s on its own — that is `pgregory.net/rapid` property tests under `-race`, and it sits close enough to the 10-minute default that CI (which does not pass `-timeout`) has little headroom on a slow runner. That is pre-existing and outside this PR's scope, but worth flagging.

The package this PR touches passed in the same full run:

```
ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	188.022s
```

</details>

<details>
<summary>Cross-process determinism: 15 independent processes, all 194567 gas</summary>

Each invocation is a separate process, so each gets fresh Go map-iteration seeds and freshly randomized genesis validator/account keys.

```
$ for i in $(seq 1 15); do go test ./x/rollapp/keeper/ -run TestCreateRollappGasIsDeterministic -count=1; done
run 1: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.671s
run 2: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.458s
run 3: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.515s
run 4: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.529s
run 5: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.651s
run 6: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.520s
run 7: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.465s
run 8: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.786s
run 9: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.612s
run 10: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.417s
run 11: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.445s
run 12: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.555s
run 13: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	0.451s
run 14: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	1.018s
run 15: ok  	github.com/dymensionxyz/dymension/v3/x/rollapp/keeper	1.332s
any failure: 0
```

The absolute figure is stable across processes too, not merely self-consistent within one:

```
$ for i in $(seq 1 8); do go test ./x/rollapp/keeper/ -run TestCreateRollappGasIsDeterministic -v -count=1 | grep "simulations against"; done
    20 simulations against identical committed state: 194567 gas each
    20 simulations against identical committed state: 194567 gas each
    20 simulations against identical committed state: 194567 gas each
    20 simulations against identical committed state: 194567 gas each
    20 simulations against identical committed state: 194567 gas each
    20 simulations against identical committed state: 194567 gas each
    20 simulations against identical committed state: 194567 gas each
    20 simulations against identical committed state: 194567 gas each
```

</details>

<details>
<summary>Controlled measurement of the first-use pubkey cost</summary>

Throwaway diagnostic, not committed. Two chains built identically; the only difference is whether the signer's pubkey was already persisted on its account before the byte-identical tx was simulated.

```
=== RUN   TestScratchPubkeyIsolated
    pubkey already persisted=false seq=0 -> gas 194567
    pubkey already persisted=true  seq=0 -> gas 180994
--- PASS: TestScratchPubkeyIsolated
```

13573 gas, attributable purely to persisting the pubkey on first use. The end-to-end version — simulate at sequence 0, deliver an unrelated tx so the pubkey lands on chain, simulate again at sequence 1 — showed the same thing:

```
=== RUN   TestScratchFirstTxDelta
    before: pubkey on chain = false, seq = 0
    after:  pubkey on chain = true, seq = 1
    gas first tx (seq 0, pubkey unset) = 194567
    gas later tx (seq 1, pubkey set)   = 181068
    delta = 13499 ; CLI default gas limit = 200000
--- PASS: TestScratchFirstTxDelta
```

Also measured: gas is unchanged across block boundaries when nothing the tx reads changes, and simulation leaves no residue.

```
=== RUN   TestScratchIsolation
    rollapp present in checkState after 3 simulations: false
    creator sequence in checkState after 3 simulations: 0
    height 1 committed: simulate gas = 194567
    height 2 committed: simulate gas = 194567
    height 3 committed: simulate gas = 194567
    height 4 committed: simulate gas = 194567
    height 5 committed: simulate gas = 194567
    height 6 committed: simulate gas = 194567
--- PASS: TestScratchIsolation
```

And the sensitivity control confirming the measurement is live:

```
=== RUN   TestScratchSensitivity
    gas baseline = 194567, gas with larger genesis checksum = 196233, delta = 1666
--- PASS: TestScratchSensitivity
```

</details>

<details>
<summary>Ruling out simulate-state leakage as the historical cause</summary>

`git log` on `go.mod` shows the repo was on cosmos-sdk **v0.47.13** when the issue was filed in October 2024. Both that version and today's v0.50.14 branch the simulation into a cache context whose write function is discarded, so a simulation cannot mutate the check state that the next one reads.

v0.47.13 `baseapp/baseapp.go`:

```go
	if mode == runTxModeSimulate {
		ctx, _ = ctx.CacheContext()
	}
```

v0.50.14 `baseapp/baseapp.go`:

```go
	if mode == execModeSimulate {
		ctx, _ = ctx.CacheContext()
		ctx = ctx.WithExecMode(sdk.ExecMode(execModeSimulate))
	}
```

In both, `runTx` writes the message cache back only in finalize mode. So repeated simulations were independent then and are independent now — leakage was never the mechanism.

</details>

<details>
<summary>Pre-existing lint findings reproduced on the merge base</summary>

Scoped lint with my file present reports three `staticcheck` findings, all in `x/rollapp/keeper/invariants.go`, a file this PR does not touch. Removing my file so the tree matches HEAD reproduces exactly the same three:

```
$ git status --porcelain    # my file removed; tree == HEAD
(clean)
$ golangci-lint run ./x/rollapp/...
x/rollapp/keeper/invariants.go:64:5: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
x/rollapp/keeper/invariants.go:71:5: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
x/rollapp/keeper/invariants.go:76:5: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
3 issues:
* staticcheck: 3
```

These surface on the locally available golangci-lint v2.12.2; CI pins v2.1, whose staticcheck does not carry the `QF1012` quickfix. Zero findings in the file this PR adds.

</details>

<details>
<summary>Not run: E2E</summary>

The three E2E workflows are `workflow_dispatch`/nightly only and do not gate pull requests; they build a Docker image and hand off to `dymensionxyz/e2e-tests`, which drives external rollapp images. This PR adds no production code, so there is no behaviour for them to exercise. `proto.yaml` is opt-in via the `enable-proto-checks` label and no `.proto` files changed.

</details>
